### PR TITLE
add rbe-debian8 container by container_layer

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,9 +22,9 @@ load(
 # https://docs.bazel.build/versions/master/be/workspace.html#git_repository
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "bc2182a51e19bf1fe5c3c33636b3e2827fac7be34af07690f9d612ca9bf31c3b",
-    strip_prefix = "rules_docker-4d49182a85c745065e621c145238c5e9420ed91b",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/4d49182a85c745065e621c145238c5e9420ed91b.tar.gz"],
+    sha256 = "d2e6408b8f8b03ad1f2172acadf979204dedd0423c5194a82a1301cc6d1c224b",
+    strip_prefix = "rules_docker-17f2587dc58642cd494b9d56890e6210f406380d",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/17f2587dc58642cd494b9d56890e6210f406380d.tar.gz"],
 )
 
 load(

--- a/container/experimental/rbe-debian8/BUILD
+++ b/container/experimental/rbe-debian8/BUILD
@@ -19,11 +19,6 @@ package(default_visibility = ["//visibility:public"])
 load("@distroless//cacerts:cacerts.bzl", "cacerts")
 load("@jessie_package_bundle//file:packages.bzl", "packages")
 load(
-    "//container/rules:docker_toolchains.bzl",
-    "language_tool_layer",
-    "toolchain_container",
-)
-load(
     "//skylib:packages.bzl",
     "base_layer_packages",
     "clang_layer_packages",
@@ -31,21 +26,21 @@ load(
     "python_layer_packages",
 )
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "container_image",
+    "container_layer",
+)
 
 cacerts(
     name = "cacerts",
     deb = packages["ca-certificates"],
 )
 
-toolchain_container(
+container_image(
     name = "fl-toolchain",
     base = "@debian8//image",
-    env = {
-        # PATH envvar is a special case, and currently only the one in the
-        # topmost layer is set. So that we override it here to include all.
-        "PATH": "/opt/python3.6/bin:/usr/local/go/bin:$PATH",
-    },
-    language_layers = [
+    layers = [
         "base-ltl",
         "clang-ltl",
         "go-ltl",
@@ -55,9 +50,8 @@ toolchain_container(
     tags = ["manual"],
 )
 
-language_tool_layer(
+container_layer(
     name = "base-ltl",
-    base = "@debian8//image",
     debs = base_layer_packages(),
     tags = ["manual"],
     tars = [
@@ -65,9 +59,8 @@ language_tool_layer(
     ],
 )
 
-language_tool_layer(
+container_layer(
     name = "clang-ltl",
-    base = "@debian8//image",
     debs = clang_layer_packages(),
     env = {
         "CC": "/usr/local/bin/clang",
@@ -76,20 +69,18 @@ language_tool_layer(
     tars = ["//third_party/clang:tar"],
 )
 
-language_tool_layer(
+container_layer(
     name = "go-ltl",
-    base = "@debian8//image",
     env = {
         "GOPATH": "/go",
-        "PATH": "$PATH:/usr/local/go/bin",
+        "PATH": "/usr/local/go/bin:$PATH",
     },
     tags = ["manual"],
     tars = ["//third_party/golang:tar"],
 )
 
-language_tool_layer(
+container_layer(
     name = "java-ltl",
-    base = "@debian8//image",
     debs = java_layer_packages(),
     env = {
         "JAVA_HOME": "/usr/lib/jvm/java-8-openjdk-amd64",
@@ -100,12 +91,11 @@ language_tool_layer(
     tags = ["manual"],
 )
 
-language_tool_layer(
+container_layer(
     name = "python-ltl",
-    base = "@debian8//image",
     debs = python_layer_packages(),
     env = {
-        "PATH": "$PATH:/opt/python3.6/bin",
+        "PATH": "/opt/python3.6/bin:$PATH",
     },
     symlinks = {
         "/usr/bin/python": "/usr/bin/python2.7",

--- a/container/rules/docker_toolchains.bzl
+++ b/container/rules/docker_toolchains.bzl
@@ -76,7 +76,7 @@ def _toolchain_container_impl(ctx):
   symlinks = {}
   # TODO(ngiraldo): we rewrite env and symlinks if there are conficts,
   # warn the user of conflicts or error out.
-  for layer in ctx.attr.layers:
+  for layer in ctx.attr.language_layers:
     debs.extend(layer.debs)
     tars.extend(layer.tars)
     files.extend(layer.input_files)
@@ -92,7 +92,7 @@ def _toolchain_container_impl(ctx):
 
 toolchain_container_ = rule(
     attrs = _container.image.attrs + {
-        "layers": attr.label_list(),
+        "language_layers": attr.label_list(),
     },
     executable = True,
     outputs = _container.image.outputs,

--- a/container/test/BUILD
+++ b/container/test/BUILD
@@ -1,0 +1,19 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+licenses(["notice"])  # Apache 2.0
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files(glob(["**"]))

--- a/container/test/rbe-debian8.yaml
+++ b/container/test/rbe-debian8.yaml
@@ -13,9 +13,42 @@ commandTests:
 - name: 'gopath-envvar'
   command: ['sh', '-c', 'echo $GOPATH']
   expectedOutput: ['/go']
+- name: 'clang-version'
+  command: ['bash', '-c', 'clang --version']
+  expectedOutput: ['clang version 7.0.0.*']
+- name: 'java-version'
+  command: ['bash', '-c', 'java -version 2>&1']
+  expectedOutput: ['openjdk version \"1.8.*']
+- name: 'python2-version'
+  command: ['bash', '-c', 'python -V 2>&1']
+  expectedOutput: ['Python 2.7.9']
 - name: 'python3-version'
-  command: ['python3', '-V']
+  command: ['bash', '-c', 'python3 -V']
   expectedOutput: ['Python 3.6.2']
+- name: 'go-version'
+  command: ['bash', '-c', 'go version']
+  expectedOutput: ['go version go1.9.4 linux/amd64']
+- name: 'check-curl'
+  command: ['bash', '-c', 'curl --version']
+  expectedOutput: ['curl .* \(x86_64-pc-linux-gnu\).*']
+- name: 'check-ed'
+  command: ['bash', '-c', 'ed --version']
+  expectedOutput: ['GNU Ed .*']
+- name: 'check-file'
+  command: ['bash', '-c', 'file --version']
+  expectedOutput: ['file-.*']
+- name: 'check-git'
+  command: ['bash', '-c', 'git --version']
+  expectedOutput: ['git version .*']
+- name: 'check-openssl'
+  command: ['bash', '-c', 'openssl version']
+  expectedOutput: ['OpenSSL .*']
+- name: 'check-wget'
+  command: ['bash', '-c', 'wget --version']
+  expectedOutput: ['GNU Wget.* built on linux-gnu.*']
+- name: 'check-zip'
+  command: ['bash', '-c', 'zip --version']
+  expectedOutput: ['.*This is Zip.*']
 
 fileExistenceTests:
 - name: 'Root'

--- a/container/test/rbe-debian8.yaml
+++ b/container/test/rbe-debian8.yaml
@@ -1,9 +1,21 @@
 schemaVersion: "1.0.0"
 
 commandTests:
-- name: 'path'
+- name: 'path-envvar'
   command: ['sh', '-c', 'echo $PATH']
-  expectedOutput: ['/usr/local/go/bin:/opt/python3.6/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin']
+  expectedOutput: ['/opt/python3.6/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin']
+- name: 'cc-envvar'
+  command: ['sh', '-c', 'echo $CC']
+  expectedOutput: ['/usr/local/bin/clang']
+- name: 'javahome-envvar'
+  command: ['sh', '-c', 'echo $JAVA_HOME']
+  expectedOutput: ['/usr/lib/jvm/java-8-openjdk-amd64']
+- name: 'gopath-envvar'
+  command: ['sh', '-c', 'echo $GOPATH']
+  expectedOutput: ['/go']
+- name: 'python3-version'
+  command: ['python3', '-V']
+  expectedOutput: ['Python 3.6.2']
 
 fileExistenceTests:
 - name: 'Root'


### PR DESCRIPTION
* make use of container_layer rule to generate the experimental
rbe-debian8 container.
* rbe-debian8 container can pass the same tests as the current
debian8-clang-fully-loaded container
* since `layers` attr is used in container_image rule, we rename
`layers` -> `language_layers`

Tested:
- bazel test //container/debian8-clang-fully-loaded:all
- bazel test //container/experimental/rbe-debian8:all

Change-Id: I7c4a9e626d720d94f6f730f31f3f4d57c35a9a10