### PR TITLE
fix test.yaml name/location for GCB build

### DIFF
--- a/container/debian8-clang-fully-loaded/build.sh
+++ b/container/debian8-clang-fully-loaded/build.sh
@@ -102,7 +102,7 @@ main () {
   # mount the full root directory (to use bazel builder properly).
   cd ${PROJECT_ROOT}
   # We need to run clean to make sure we don't mount local build outputs
-  bazel clean --async
+  bazel clean
 
   if [[ "$LOCAL" = true ]]; then
     echo "Building container locally."

--- a/container/debian8-clang-fully-loaded/cloudbuild.yaml
+++ b/container/debian8-clang-fully-loaded/cloudbuild.yaml
@@ -33,7 +33,7 @@ steps:
   - name: gcr.io/gcp-runtimes/structure_test
     args: [
     '--image', 'gcr.io/${_PROJECT}/${_CONTAINER}:${_TAG}',
-    '--config', '/workspace/container/debian8-clang-fully-loaded/test.yaml']
+    '--config', '/workspace/container/test/rbe-debian8.yaml']
 
 # Build the release-container
 images:


### PR DESCRIPTION
Tested:
- container/debian8-clang-fully-loaded/build.sh -p my-project -c gcr.io/mp-project/my-image -t fix-test

Change-Id: Ib47b86f822312102321aa48e46d0309423ca0799