### PR TITLE
adding env variable for llvm-symbolizer to clang layer

### DIFF
--- a/container/debian8-clang-fully-loaded/BUILD
+++ b/container/debian8-clang-fully-loaded/BUILD
@@ -71,6 +71,7 @@ language_tool_layer(
     debs = clang_layer_packages(),
     env = {
         "CC": "/usr/local/bin/clang",
+        "ASAN_SYMBOLIZER_PATH": "/usr/local/bin/llvm-symbolizer",
     },
     tags = ["manual"],
     tars = ["//third_party/clang:tar"],


### PR DESCRIPTION
As indicated in sanitizer instructions (https://clang.llvm.org/docs/AddressSanitizer.html#symbolizing-the-reports) this env variable can be used to define the path to the llvm-symbolizer so asan can produce correct stack traces