### PR TITLE
add local container test to PR presubmit

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -13,6 +13,7 @@ platforms:
     - "//test:debian8_clang_autoconfig_test"
     - "//rules:debian8-clang-0.2.0-bazel_0.9.0-autoconfig_test"
     - "//rules:debian8-clang-0.3.0-bazel_0.10.0-autoconfig_test"
+    - "//container/debian8-clang-fully-loaded:fl-toolchain-test"
   ubuntu1604:
     test_targets:
     - "//test:debian-jessie-autoconfig_test"
@@ -26,3 +27,4 @@ platforms:
     - "//test:debian8_clang_autoconfig_test"
     - "//rules:debian8-clang-0.2.0-bazel_0.9.0-autoconfig_test"
     - "//rules:debian8-clang-0.3.0-bazel_0.10.0-autoconfig_test"
+    - "//container/debian8-clang-fully-loaded:fl-toolchain-test"


### PR DESCRIPTION
Presubmit will build and test `debian8-clang-fully-loaded` container locally 

Change-Id: If2b12404d2ca7bc90f7689599b30166f3484a8d5