### PR TITLE
temporarily disable container tests

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -13,6 +13,7 @@ platforms:
     - "//test/configs:debian8_clang_autoconfig_test"
     - "//rules:debian8-clang-0.3.0-bazel_0.10.0-autoconfig_test"
     - "//container/rbe-debian8:toolchain-test"
+    # TODO: turn in these tests once issue with Bazel CI is resolved
     # - "//container/experimental/rbe-debian9:toolchain-test"
     # - "//container/experimental/rbe-ubuntu16_04:toolchain-test"
   ubuntu1604:
@@ -28,5 +29,6 @@ platforms:
     - "//test/configs:debian8_clang_autoconfig_test"
     - "//rules:debian8-clang-0.3.0-bazel_0.10.0-autoconfig_test"
     - "//container/rbe-debian8:toolchain-test"
+    # TODO: turn in these tests once issue with Bazel CI is resolved
     # - "//container/experimental/rbe-debian9:toolchain-test"
     # - "//container/experimental/rbe-ubuntu16_04:toolchain-test"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -13,8 +13,8 @@ platforms:
     - "//test/configs:debian8_clang_autoconfig_test"
     - "//rules:debian8-clang-0.3.0-bazel_0.10.0-autoconfig_test"
     - "//container/rbe-debian8:toolchain-test"
-    - "//container/experimental/rbe-debian9:toolchain-test"
-    - "//container/experimental/rbe-ubuntu16_04:toolchain-test"
+    # - "//container/experimental/rbe-debian9:toolchain-test"
+    # - "//container/experimental/rbe-ubuntu16_04:toolchain-test"
   ubuntu1604:
     test_targets:
     - "//test/configs:debian-jessie-autoconfig_test"
@@ -28,5 +28,5 @@ platforms:
     - "//test/configs:debian8_clang_autoconfig_test"
     - "//rules:debian8-clang-0.3.0-bazel_0.10.0-autoconfig_test"
     - "//container/rbe-debian8:toolchain-test"
-    - "//container/experimental/rbe-debian9:toolchain-test"
-    - "//container/experimental/rbe-ubuntu16_04:toolchain-test"
+    # - "//container/experimental/rbe-debian9:toolchain-test"
+    # - "//container/experimental/rbe-ubuntu16_04:toolchain-test"


### PR DESCRIPTION
- due to Bazel CI problem, see comments in
  https://github.com/bazelbuild/bazel-toolchains/pull/18
