### PR TITLE
Add `default` parameter to `attr.string_list([..])` call

### DIFF
--- a/rules/docker_config.bzl
+++ b/rules/docker_config.bzl
@@ -335,7 +335,7 @@ def _docker_toolchain_autoconfig_impl(ctx):
 
 docker_toolchain_autoconfig_ = rule(
     attrs = _container.image.attrs + {
-        "config_repos": attr.string_list(["local_config_cc"]),
+        "config_repos": attr.string_list(default = ["local_config_cc"]),
         "use_default_project": attr.bool(default = False),
         "git_repo": attr.string(),
         "repo_pkg_tar": attr.label(allow_files = tar_filetype),


### PR DESCRIPTION
Breakage introduced with 0.13.0rc1. See https://buildkite.com/bazel/bazel-with-downstream-projects-bazel/builds/188#4ca52218-5bde-44c1-bcda-22556ae7b461

Fixes https://github.com/bazelbuild/bazel/issues/4992