### PR TITLE
use debian9 clang tarball for rbe-debian9 container

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -189,6 +189,12 @@ http_file(
 )
 
 http_file(
+    name = "debian9_clang_release",
+    sha256 = "434bbe2195845e42eb36ad2b88f6aec658d192614d47f71e15b861e09f71b4bd",
+    urls = ["https://storage.googleapis.com/clang-builds-stable/clang-debian9/clang_" + CLANG_REVISION + ".tar.gz"],
+)
+
+http_file(
     name = "ubuntu16_04_clang_release",
     sha256 = "48bfc470810d483ffb2e826ed3540efc1da45fa89f416f8efa439242495e6239",
     urls = ["https://storage.googleapis.com/clang-builds-stable/clang-ubuntu16_04/clang_" + CLANG_REVISION + ".tar.gz"],

--- a/container/experimental/rbe-debian9/BUILD
+++ b/container/experimental/rbe-debian9/BUILD
@@ -68,8 +68,7 @@ language_tool_layer(
     packages = [
         "libstdc++-6-dev",
     ],
-    # TODO: change to clang for debian9 once it's available.
-    tars = ["//third_party/clang:debian8_tar"],
+    tars = ["//third_party/clang:debian9_tar"],
 )
 
 language_tool_layer(

--- a/third_party/clang/BUILD
+++ b/third_party/clang/BUILD
@@ -39,6 +39,20 @@ pkg_tar(
 )
 
 pkg_tar(
+    name = "debian9_tar",
+    srcs = glob(
+        ["**/*"],
+        exclude = ["**/BUILD"],
+    ),
+    package_dir = "/usr/local/",
+    strip_prefix = ".",
+    tags = ["manual"],
+    deps = [
+        "@debian9_clang_release//file",
+    ],
+)
+
+pkg_tar(
     name = "ubuntu16_04_tar",
     srcs = glob(
         ["**/*"],


### PR DESCRIPTION
- previously we use clang tarball built from debian8 for rbe-debian9
- now we switch to clang tarball bult from debian9 since it is available