### PR TITLE
update rbe-debian8 container's sha256

### DIFF
--- a/bazelrc/bazel-0.10.0.bazelrc
+++ b/bazelrc/bazel-0.10.0.bazelrc
@@ -33,7 +33,7 @@ build:remote --jobs=50
 build:remote --host_javabase=@bazel_toolchains//configs/debian8_clang/0.3.0:jdk8
 build:remote --javabase=@bazel_toolchains//configs/debian8_clang/0.3.0:jdk8
 build:remote --crosstool_top=@bazel_toolchains//configs/debian8_clang/0.3.0/bazel_0.10.0:toolchain
-build:remote --experimental_remote_platform_override='properties:{ name:"container-image" value:"docker://gcr.io/cloud-marketplace/google/rbe-debian8@sha256:1ede2a929b44d629ec5abe86eee6d7ffea1d5a4d247489a8867d46cfde3e38bd" }'
+build:remote --experimental_remote_platform_override='properties:{ name:"container-image" value:"docker://gcr.io/cloud-marketplace/google/rbe-debian8@sha256:d84a7de5175a22505209f56b02f1da20ccec64880da09ee38eaef3670fbd2a56" }'
 
 # Set various strategies so that all actions execute remotely. Mixing remote
 # and local execution will lead to errors unless the toolchain and remote

--- a/configs/debian8_clang/0.3.0/toolchain.bazelrc
+++ b/configs/debian8_clang/0.3.0/toolchain.bazelrc
@@ -2,7 +2,7 @@
 build:remote --host_javabase=@bazel_toolchains//configs/debian8_clang/0.3.0:jdk8
 build:remote --javabase=@bazel_toolchains//configs/debian8_clang/0.3.0:jdk8
 build:remote --crosstool_top=@bazel_toolchains//configs/debian8_clang/0.3.0/bazel_0.10.0:toolchain
-build:remote --experimental_remote_platform_override='properties:{ name:"container-image" value:"docker://gcr.io/cloud-marketplace/google/rbe-debian8@sha256:1ede2a929b44d629ec5abe86eee6d7ffea1d5a4d247489a8867d46cfde3e38bd" }'
+build:remote --experimental_remote_platform_override='properties:{ name:"container-image" value:"docker://gcr.io/cloud-marketplace/google/rbe-debian8@sha256:d84a7de5175a22505209f56b02f1da20ccec64880da09ee38eaef3670fbd2a56" }'
 
 # Experimental configs for sanitizers, use --config=remote,remote-xxsan,remote-<asan/tsan/msan> (in that order)
 build:remote-xxsan --copt=-gmlt

--- a/platforms/experimental/BUILD
+++ b/platforms/experimental/BUILD
@@ -36,7 +36,7 @@ platform(
     remote_execution_properties = """
           properties: {
             name: "container-image"
-            value:"docker://gcr.io/cloud-marketplace/google/rbe-debian8@sha256:1ede2a929b44d629ec5abe86eee6d7ffea1d5a4d247489a8867d46cfde3e38bd"
+            value:"docker://gcr.io/cloud-marketplace/google/rbe-debian8@sha256:d84a7de5175a22505209f56b02f1da20ccec64880da09ee38eaef3670fbd2a56"
          }
          """,
 )


### PR DESCRIPTION
New rbe-debian8 container on Google Cloud Launcher: launcher.gcr.io/google/rbe-debian8:r327695