### PR TITLE
switch to Skylark version of http_archive

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,6 +13,7 @@
 # limitations under the License.
 workspace(name = "bazel_toolchains")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load(
     "//skylib:package_names.bzl",
     "jessie_package_names",


### PR DESCRIPTION
[Bazel 0.12.0 release notes](https://blog.bazel.build/2018/04/11/bazel-0.12.html) say:

> The native http_archive rule has been deprecated. Use the Skylark version available via load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive") instead.

> The native git_repository rule has been deprecated. Use the Skylark version available via load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository") instead.
