### PR TITLE
update hash of bazel's gpg key

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -107,7 +107,7 @@ http_archive(
 
 http_file(
     name = "bazel_gpg",
-    sha256 = "e0e806160454a3e5e308188439525896bf9881f1f2f0b887192428f517da4131",
+    sha256 = "30af2ca7abfb65987cd61802ca6e352aadc6129dfb5bfc9c81f16617bc3a4416",
     url = "https://bazel.build/bazel-release.pub.gpg",
 )
 


### PR DESCRIPTION
Bazel's gpg key expired yesterday and so we updated the expiration date, leading to a different hash of the public key.

This currently breaks the build