### PR TITLE
fix default cmd (bash) and locale (C.UTF-8)

### DIFF
--- a/container/experimental/rbe-debian8/BUILD
+++ b/container/experimental/rbe-debian8/BUILD
@@ -40,8 +40,15 @@ cacerts(
 container_image(
     name = "toolchain",
     base = "@debian8//image",
+    cmd = [
+        "/bin/sh",
+        "-c",
+        "/bin/bash",
+    ],
     env = {
-        "LC_ALL ": "C.UTF-8",
+        "LANG": "C.UTF-8",
+        "LANGUAGE": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
     },
     layers = [
         ":base-ltl",

--- a/container/experimental/rbe-debian9/BUILD
+++ b/container/experimental/rbe-debian9/BUILD
@@ -37,11 +37,18 @@ PYTHON_CLEANUP_COMMANDS = (
 toolchain_container(
     name = "toolchain",
     base = "@debian9//image",
+    cmd = [
+        "/bin/sh",
+        "-c",
+        "/bin/bash",
+    ],
     env = {
         # PATH envvar is a special case, and currently only the one in the
         # topmost layer is set. So that we override it here to include all.
         "PATH": "$PATH:/usr/local/go/bin",
-        "LC_ALL ": "C.UTF-8",
+        "LANG": "C.UTF-8",
+        "LANGUAGE": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
     },
     language_layers = [
         "base-ltl",

--- a/container/rbe-debian8/BUILD
+++ b/container/rbe-debian8/BUILD
@@ -37,11 +37,18 @@ PYTHON_CLEANUP_COMMANDS = (
 toolchain_container(
     name = "toolchain",
     base = "@debian8//image",
+    cmd = [
+        "/bin/sh",
+        "-c",
+        "/bin/bash",
+    ],
     env = {
         # PATH envvar is a special case, and currently only the one in the
         # topmost layer is set. So that we override it here to include all.
         "PATH": "$PATH:/opt/python3.6/bin:/usr/local/go/bin",
-        "LC_ALL ": "C.UTF-8",
+        "LANG": "C.UTF-8",
+        "LANGUAGE": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
     },
     language_layers = [
         "base-ltl",

--- a/container/rbe-ubuntu16_04/BUILD
+++ b/container/rbe-ubuntu16_04/BUILD
@@ -37,11 +37,18 @@ PYTHON_CLEANUP_COMMANDS = (
 toolchain_container(
     name = "toolchain",
     base = "@ubuntu16_04//image",
+    cmd = [
+        "/bin/sh",
+        "-c",
+        "/bin/bash",
+    ],
     env = {
         # PATH envvar is a special case, and currently only the one in the
         # topmost layer is set. So that we override it here to include all.
         "PATH": "$PATH:/opt/python3.6/bin:/usr/local/go/bin",
-        "LC_ALL ": "C.UTF-8",
+        "LANG": "C.UTF-8",
+        "LANGUAGE": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
     },
     language_layers = [
         "base-ltl",
@@ -63,6 +70,8 @@ language_tool_layer(
         "file",
         "git",
         "less",
+        "locales",
+        "locales-all",
         "netcat",
         "openssh-client",
         "patch",

--- a/container/test/rbe-debian8.yaml
+++ b/container/test/rbe-debian8.yaml
@@ -18,6 +18,9 @@ commandTests:
 - name: 'path-envvar'
   command: ['sh', '-c', 'echo $PATH']
   expectedOutput: ['/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/python3.6/bin:/usr/local/go/bin']
+- name: 'check-locale'
+  command: ['sh', '-c', 'echo $LC_ALL']
+  expectedOutput: ['C.UTF-8']
 - name: 'cc-envvar'
   command: ['sh', '-c', 'echo $CC']
   expectedOutput: ['/usr/local/bin/clang']

--- a/container/test/rbe-debian9.yaml
+++ b/container/test/rbe-debian9.yaml
@@ -18,6 +18,9 @@ commandTests:
 - name: 'path-envvar'
   command: ['sh', '-c', 'echo $PATH']
   expectedOutput: ['/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin']
+- name: 'check-locale'
+  command: ['sh', '-c', 'echo $LC_ALL']
+  expectedOutput: ['C.UTF-8']
 - name: 'cc-envvar'
   command: ['sh', '-c', 'echo $CC']
   expectedOutput: ['/usr/local/bin/clang']

--- a/container/test/rbe-ubuntu16_04.yaml
+++ b/container/test/rbe-ubuntu16_04.yaml
@@ -18,6 +18,9 @@ commandTests:
 - name: 'path-envvar'
   command: ['sh', '-c', 'echo $PATH']
   expectedOutput: ['/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/python3.6/bin:/usr/local/go/bin']
+- name: 'check-locale'
+  command: ['sh', '-c', 'echo $LC_ALL']
+  expectedOutput: ['C.UTF-8']
 - name: 'cc-envvar'
   command: ['sh', '-c', 'echo $CC']
   expectedOutput: ['/usr/local/bin/clang']


### PR DESCRIPTION
Tested: rbe-{debian8,debian9,ubuntu16_04} are all tested with Google
Container Builder