### PR TITLE
Show more error message in container_test.

### DIFF
--- a/container/cloudbuild.yaml
+++ b/container/cloudbuild.yaml
@@ -49,7 +49,7 @@ steps:
     args: [
       '--output_base=/workspace',
       'test',
-      '--test_output=errors',
+      '--test_output=all',
       '--verbose_failures',
       '--spawn_strategy=standalone',
       '--genrule_strategy=standalone',

--- a/container/cloudbuild_no_bucket.yaml
+++ b/container/cloudbuild_no_bucket.yaml
@@ -49,7 +49,7 @@ steps:
     args: [
       '--output_base=/workspace',
       'test',
-      '--test_output=errors',
+      '--test_output=all',
       '--verbose_failures',
       '--spawn_strategy=standalone',
       '--genrule_strategy=standalone',

--- a/container/experimental/rbe-debian8/BUILD
+++ b/container/experimental/rbe-debian8/BUILD
@@ -127,4 +127,5 @@ container_test(
     name = "toolchain-test",
     configs = ["//container/rbe-debian8:rbe-debian8.yaml"],
     image = ":toolchain",
+    verbose = True,
 )

--- a/container/experimental/rbe-debian9/BUILD
+++ b/container/experimental/rbe-debian9/BUILD
@@ -155,4 +155,5 @@ container_test(
         ":rbe-debian9.yaml",
     ],
     image = ":toolchain",
+    verbose = True,
 )

--- a/container/rbe-debian8/BUILD
+++ b/container/rbe-debian8/BUILD
@@ -154,4 +154,5 @@ container_test(
         ":rbe-debian8.yaml",
     ],
     image = ":toolchain",
+    verbose = True,
 )

--- a/container/rbe-ubuntu16_04/BUILD
+++ b/container/rbe-ubuntu16_04/BUILD
@@ -153,4 +153,5 @@ container_test(
         ":rbe-ubuntu16_04.yaml",
     ],
     image = ":toolchain",
+    verbose = True,
 )


### PR DESCRIPTION
Yaml config validation error doesn't fail container_test version 2.0.0.
https://github.com/GoogleContainerTools/container-structure-test/issues/146

This is not an issue with container_test version 1.0.0 (which is
currently used), but it still makes sense to print out detailed
log of container_test.