### PR TITLE
Support latest version of Bazel

### DIFF
--- a/configs/experimental/windows/0.1.0/bazel_experimental/BUILD
+++ b/configs/experimental/windows/0.1.0/bazel_experimental/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2016 The Bazel Authors. All rights reserved.
+# Copyright 2018 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# This becomes the BUILD file for @local_config_cc// under Windows.
 
 package(default_visibility = ["//visibility:public"])
 
@@ -32,40 +34,11 @@ cc_toolchain_suite(
     name = "toolchain",
     toolchains = {
         "armeabi-v7a|compiler": ":cc-compiler-armeabi-v7a",
-        "freebsd|compiler": ":cc-compiler-freebsd",
         "x64_windows|msvc-cl": ":cc-compiler-x64_windows",
         "x64_windows|msys-gcc": ":cc-compiler-x64_windows_msys",
         "x64_windows|mingw-gcc": ":cc-compiler-x64_windows_mingw",
         "ios_x86_64|compiler": ":cc-compiler-ios_x86_64",
     },
-)
-
-cc_toolchain(
-    name = "cc-compiler-armeabi-v7a",
-    all_files = ":empty",
-    compiler_files = ":empty",
-    cpu = "local",
-    dwp_files = ":empty",
-    dynamic_runtime_libs = [":empty"],
-    linker_files = ":empty",
-    objcopy_files = ":empty",
-    static_runtime_libs = [":empty"],
-    strip_files = ":empty",
-    supports_param_files = 1,
-)
-
-cc_toolchain(
-    name = "cc-compiler-freebsd",
-    all_files = ":empty",
-    compiler_files = ":empty",
-    cpu = "local",
-    dwp_files = ":empty",
-    dynamic_runtime_libs = [":empty"],
-    linker_files = ":empty",
-    objcopy_files = ":empty",
-    static_runtime_libs = [":empty"],
-    strip_files = ":empty",
-    supports_param_files = 0,
 )
 
 cc_toolchain(
@@ -82,6 +55,21 @@ cc_toolchain(
     supports_param_files = 1,
 )
 
+toolchain(
+    name = "cc-toolchain-x64_windows_msys",
+    exec_compatible_with = [
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//platforms:windows",
+        "@bazel_tools//tools/cpp:msys",
+    ],
+    target_compatible_with = [
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//platforms:windows",
+    ],
+    toolchain = ":cc-compiler-x64_windows_msys",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+
 cc_toolchain(
     name = "cc-compiler-x64_windows_mingw",
     all_files = ":empty",
@@ -93,7 +81,22 @@ cc_toolchain(
     objcopy_files = ":empty",
     static_runtime_libs = [":empty"],
     strip_files = ":empty",
-    supports_param_files = 1,
+    supports_param_files = 0,
+)
+
+toolchain(
+    name = "cc-toolchain-x64_windows_mingw",
+    exec_compatible_with = [
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//platforms:windows",
+        "@bazel_tools//tools/cpp:mingw",
+    ],
+    target_compatible_with = [
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//platforms:windows",
+    ],
+    toolchain = ":cc-compiler-x64_windows_mingw",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 )
 
 cc_toolchain(
@@ -110,6 +113,46 @@ cc_toolchain(
     supports_param_files = 1,
 )
 
+toolchain(
+    name = "cc-toolchain-x64_windows",
+    exec_compatible_with = [
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//platforms:windows",
+    ],
+    target_compatible_with = [
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//platforms:windows",
+    ],
+    toolchain = ":cc-compiler-x64_windows",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+
+cc_toolchain(
+    name = "cc-compiler-armeabi-v7a",
+    all_files = ":empty",
+    compiler_files = ":empty",
+    cpu = "local",
+    dwp_files = ":empty",
+    dynamic_runtime_libs = [":empty"],
+    linker_files = ":empty",
+    objcopy_files = ":empty",
+    static_runtime_libs = [":empty"],
+    strip_files = ":empty",
+    supports_param_files = 1,
+)
+
+toolchain(
+    name = "cc-toolchain-armeabi-v7a",
+    exec_compatible_with = [
+    ],
+    target_compatible_with = [
+        "@bazel_tools//platforms:arm",
+        "@bazel_tools//platforms:android",
+    ],
+    toolchain = ":cc-compiler-armeabi-v7a",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+
 cc_toolchain(
     name = "cc-compiler-ios_x86_64",
     all_files = ":empty",
@@ -122,6 +165,18 @@ cc_toolchain(
     static_runtime_libs = [":empty"],
     strip_files = ":empty",
     supports_param_files = 0,
+)
+
+toolchain(
+    name = "cc-toolchain-ios_x86_64",
+    exec_compatible_with = [
+    ],
+    target_compatible_with = [
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//platforms:ios",
+    ],
+    toolchain = ":cc-compiler-ios_x86_64",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 )
 
 filegroup(
@@ -138,25 +193,3 @@ filegroup(
         "wrapper/bin/pydir/msvc*",
     ]),
 )
-
-# link_dynamic_library is unused. Because we don't copy link_dynamic_library.sh
-# over, Bazel complains about a missing input file.
-# filegroup(
-#     name = "link_dynamic_library",
-#     srcs = ["link_dynamic_library.sh"],
-# )
-
-cc_toolchain_type(name = "toolchain_type")
-
-# A dummy toolchain is necessary to satisfy toolchain resolution until platforms
-# are used in c++ by default.
-# TODO(b/64754003): Remove once platforms are used in c++ by default.
-toolchain(
-    name = "dummy_cc_toolchain",
-    toolchain = "dummy_cc_toolchain_impl",
-    toolchain_type = ":toolchain_type",
-)
-
-load(":dummy_toolchain.bzl", "dummy_toolchain")
-
-dummy_toolchain(name = "dummy_cc_toolchain_impl")

--- a/configs/experimental/windows/0.1.0/bazel_experimental/BUILD
+++ b/configs/experimental/windows/0.1.0/bazel_experimental/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2018 The Bazel Authors. All rights reserved.
+# Copyright 2016 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/configs/experimental/windows/0.1.0/bazel_experimental/CROSSTOOL
+++ b/configs/experimental/windows/0.1.0/bazel_experimental/CROSSTOOL
@@ -22,6 +22,11 @@ default_toolchain {
 }
 
 default_toolchain {
+  cpu: "local"
+  toolchain_identifier: "stub_armeabi-v7a"
+}
+
+default_toolchain {
   cpu: "armeabi-v7a"
   toolchain_identifier: "stub_armeabi-v7a"
 }
@@ -44,6 +49,11 @@ default_toolchain {
 default_toolchain {
   cpu: "s390x"
   toolchain_identifier: "msys_x64"
+}
+
+default_toolchain {
+  cpu: "local"
+  toolchain_identifier: "ios_x86_64"
 }
 
 default_toolchain {
@@ -132,6 +142,7 @@ toolchain {
    tool_path { name: "cpp" path: "c:/tools/msys64/usr/bin/cpp" }
    tool_path { name: "dwp" path: "c:/tools/msys64/usr/bin/dwp" }
    tool_path { name: "gcc" path: "c:/tools/msys64/usr/bin/gcc" }
+   artifact_name_pattern { category_name: "executable" prefix: "" extension: ".exe"}
    cxx_flag: "-std=gnu++0x"
    linker_flag: "-lstdc++"
    cxx_builtin_include_directory: "c:/tools/msys64/usr/"
@@ -183,11 +194,18 @@ toolchain {
   target_cpu: "x64_windows"
   target_system_name: "local"
 
+  artifact_name_pattern {
+     category_name: 'executable'
+     prefix: ''
+     extension: '.exe'
+  }
+
    tool_path { name: "ar" path: "c:/tools/msys64/mingw64/bin/ar" }
    tool_path { name: "compat-ld" path: "c:/tools/msys64/mingw64/bin/ld" }
    tool_path { name: "cpp" path: "c:/tools/msys64/mingw64/bin/cpp" }
    tool_path { name: "dwp" path: "c:/tools/msys64/mingw64/bin/dwp" }
    tool_path { name: "gcc" path: "c:/tools/msys64/mingw64/bin/gcc" }
+   artifact_name_pattern { category_name: "executable" prefix: "" extension: ".exe"}
    cxx_flag: "-std=gnu++0x"
    linker_flag: "-lstdc++"
    cxx_builtin_include_directory: "c:/tools/msys64/mingw64/"
@@ -316,6 +334,42 @@ cxx_builtin_include_directory: "C:\\botcode\\w\\ir\\run"
     name: "no_legacy_features"
   }
 
+  artifact_name_pattern {
+     category_name: 'object_file'
+     prefix: ''
+     extension: '.obj'
+  }
+
+  artifact_name_pattern {
+     category_name: 'static_library'
+     prefix: ''
+     extension: '.lib'
+  }
+
+  artifact_name_pattern {
+     category_name: 'alwayslink_static_library'
+     prefix: ''
+     extension: '.lo.lib'
+  }
+
+  artifact_name_pattern {
+     category_name: 'executable'
+     prefix: ''
+     extension: '.exe'
+  }
+
+  artifact_name_pattern {
+     category_name: 'dynamic_library'
+     prefix: ''
+     extension: '.dll'
+  }
+
+  artifact_name_pattern {
+     category_name: 'interface_library'
+     prefix: ''
+     extension: '.if.lib'
+  }
+
   # Suppress startup banner.
   feature {
     name: "nologo"
@@ -332,9 +386,6 @@ cxx_builtin_include_directory: "C:\\botcode\\w\\ir\\run"
       action: "c++-link-dynamic-library"
       action: "c++-link-nodeps-dynamic-library"
       action: "c++-link-static-library"
-      action: "c++-link-alwayslink-static-library"
-      action: "c++-link-pic-static-library"
-      action: "c++-link-alwayslink-pic-static-library"
       flag_group {
         flag: "/nologo"
       }
@@ -367,15 +418,8 @@ cxx_builtin_include_directory: "C:\\botcode\\w\\ir\\run"
     tool {
       tool_path: 'C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/amd64/ml64.exe'
     }
-    flag_set {
-      expand_if_all_available: 'output_object_file'
-      flag_group {
-        flag: '/Fo%{output_object_file}'
-        flag: '/Zi'
-        flag: '/c'
-        flag: '%{source_file}'
-      }
-    }
+    implies: 'compiler_input_flags'
+    implies: 'compiler_output_flags'
     implies: 'nologo'
     implies: 'msvc_env'
     implies: 'sysroot'
@@ -387,31 +431,8 @@ cxx_builtin_include_directory: "C:\\botcode\\w\\ir\\run"
     tool {
       tool_path: 'C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/amd64/cl.exe'
     }
-    flag_set {
-      flag_group {
-        flag: '/c'
-        flag: '%{source_file}'
-      }
-    }
-    flag_set {
-      expand_if_all_available: 'output_object_file'
-      flag_group {
-        flag: '/Fo%{output_object_file}'
-      }
-    }
-    flag_set {
-      expand_if_all_available: 'output_assembly_file'
-      flag_group {
-        flag: '/Fa%{output_assembly_file}'
-      }
-    }
-    flag_set {
-      expand_if_all_available: 'output_preprocess_file'
-      flag_group {
-        flag: '/P'
-        flag: '/Fi%{output_preprocess_file}'
-      }
-    }
+    implies: 'compiler_input_flags'
+    implies: 'compiler_output_flags'
     implies: 'legacy_compile_flags'
     implies: 'nologo'
     implies: 'msvc_env'
@@ -427,31 +448,8 @@ cxx_builtin_include_directory: "C:\\botcode\\w\\ir\\run"
     tool {
       tool_path: 'C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/amd64/cl.exe'
     }
-    flag_set {
-      flag_group {
-        flag: '/c'
-        flag: '%{source_file}'
-      }
-    }
-    flag_set {
-      expand_if_all_available: 'output_object_file'
-      flag_group {
-        flag: '/Fo%{output_object_file}'
-      }
-    }
-    flag_set {
-      expand_if_all_available: 'output_assembly_file'
-      flag_group {
-        flag: '/Fa%{output_assembly_file}'
-      }
-    }
-    flag_set {
-      expand_if_all_available: 'output_preprocess_file'
-      flag_group {
-        flag: '/P'
-        flag: '/Fi%{output_preprocess_file}'
-      }
-    }
+    implies: 'compiler_input_flags'
+    implies: 'compiler_output_flags'
     implies: 'legacy_compile_flags'
     implies: 'nologo'
     implies: 'msvc_env'
@@ -471,6 +469,7 @@ cxx_builtin_include_directory: "C:\\botcode\\w\\ir\\run"
     implies: 'linkstamps'
     implies: 'output_execpath_flags'
     implies: 'input_param_flags'
+    implies: 'user_link_flags'
     implies: 'legacy_link_flags'
     implies: 'linker_subsystem_flag'
     implies: 'linker_param_file'
@@ -490,6 +489,7 @@ cxx_builtin_include_directory: "C:\\botcode\\w\\ir\\run"
     implies: 'linkstamps'
     implies: 'output_execpath_flags'
     implies: 'input_param_flags'
+    implies: 'user_link_flags'
     implies: 'legacy_link_flags'
     implies: 'linker_subsystem_flag'
     implies: 'linker_param_file'
@@ -511,6 +511,7 @@ cxx_builtin_include_directory: "C:\\botcode\\w\\ir\\run"
       implies: 'linkstamps'
       implies: 'output_execpath_flags'
       implies: 'input_param_flags'
+      implies: 'user_link_flags'
       implies: 'legacy_link_flags'
       implies: 'linker_subsystem_flag'
       implies: 'linker_param_file'
@@ -530,58 +531,6 @@ cxx_builtin_include_directory: "C:\\botcode\\w\\ir\\run"
     implies: 'nologo'
     implies: 'archiver_flags'
     implies: 'input_param_flags'
-    implies: 'linker_param_file'
-    implies: 'msvc_env'
-  }
-
-  action_config {
-    config_name: 'c++-link-alwayslink-static-library'
-    action_name: 'c++-link-alwayslink-static-library'
-    tool {
-      tool_path: 'C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/amd64/lib.exe'
-    }
-    implies: 'nologo'
-    implies: 'archiver_flags'
-    implies: 'input_param_flags'
-    implies: 'linker_param_file'
-    implies: 'msvc_env'
-  }
-
-  # TODO(pcloudy): The following action_config is listed in MANDATORY_LINK_TARGET_TYPES.
-  # But do we really need them on Windows?
-  action_config {
-    config_name: 'c++-link-pic-static-library'
-    action_name: 'c++-link-pic-static-library'
-    tool {
-      tool_path: 'C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/amd64/lib.exe'
-    }
-    implies: 'nologo'
-    implies: 'archiver_flags'
-    implies: 'input_param_flags'
-    implies: 'linker_param_file'
-    implies: 'msvc_env'
-  }
-
-  action_config {
-    config_name: 'c++-link-alwayslink-pic-static-library'
-    action_name: 'c++-link-alwayslink-pic-static-library'
-    tool {
-      tool_path: 'C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/amd64/lib.exe'
-    }
-    implies: 'nologo'
-    implies: 'archiver_flags'
-    implies: 'input_param_flags'
-    implies: 'linker_param_file'
-    implies: 'msvc_env'
-  }
-
-  action_config {
-    config_name: 'c++-link-interface-dynamic-library'
-    action_name: 'c++-link-interface-dynamic-library'
-    tool {
-      tool_path: 'C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/amd64/lib.exe'
-    }
-    implies: 'nologo'
     implies: 'linker_param_file'
     implies: 'msvc_env'
   }
@@ -621,9 +570,6 @@ cxx_builtin_include_directory: "C:\\botcode\\w\\ir\\run"
       action: "c++-link-dynamic-library"
       action: "c++-link-nodeps-dynamic-library"
       action: "c++-link-static-library"
-      action: "c++-link-alwayslink-static-library"
-      action: "c++-link-pic-static-library"
-      action: "c++-link-alwayslink-pic-static-library"
       env_entry {
         key: "PATH"
         value: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\BIN\\amd64;C:\\Windows\\Microsoft.NET\\Framework64\\v4.0.30319;C:\\Windows\\Microsoft.NET\\Framework64\\;C:\\Program Files (x86)\\Windows Kits\\8.1\\bin\\x64;C:\\Program Files (x86)\\Windows Kits\\8.1\\bin\\x86;;C:\\Windows\\system32"
@@ -772,9 +718,6 @@ cxx_builtin_include_directory: "C:\\botcode\\w\\ir\\run"
     flag_set {
       expand_if_all_available: 'output_execpath'
       action: 'c++-link-static-library'
-      action: 'c++-link-alwayslink-static-library'
-      action: 'c++-link-pic-static-library'
-      action: 'c++-link-alwayslink-pic-static-library'
       flag_group {
         flag: '/OUT:%{output_execpath}'
       }
@@ -807,9 +750,6 @@ cxx_builtin_include_directory: "C:\\botcode\\w\\ir\\run"
       action: 'c++-link-dynamic-library'
       action: "c++-link-nodeps-dynamic-library"
       action: 'c++-link-static-library'
-      action: 'c++-link-alwayslink-static-library'
-      action: 'c++-link-pic-static-library'
-      action: 'c++-link-alwayslink-pic-static-library'
       flag_group {
         iterate_over: 'libraries_to_link'
         flag_group {
@@ -892,8 +832,8 @@ cxx_builtin_include_directory: "C:\\botcode\\w\\ir\\run"
   }
 
   # Since this feature is declared earlier in the CROSSTOOL than
-  # "legacy_link_flags", this feature will be applied prior to it anwyhere they
-  # are both implied. And since "legacy_link_flags" contains the linkopts from
+  # "user_link_flags", this feature will be applied prior to it anwyhere they
+  # are both implied. And since "user_link_flags" contains the linkopts from
   # the build rule, this allows the user to override the /SUBSYSTEM in the BUILD
   # file.
   feature {
@@ -908,11 +848,24 @@ cxx_builtin_include_directory: "C:\\botcode\\w\\ir\\run"
     }
   }
 
-  # The "legacy_link_flags" may contain user-defined linkopts (from build rules)
+  # The "user_link_flags" contains user-defined linkopts (from build rules)
   # so it should be defined after features that declare user-overridable flags.
   # For example the "linker_subsystem_flag" defines a default "/SUBSYSTEM" flag
   # but we want to let the user override it, therefore "link_flag_subsystem" is
-  # defined earlier in the CROSSTOOL file than "legacy_link_flags".
+  # defined earlier in the CROSSTOOL file than "user_link_flags".
+  feature {
+    name: 'user_link_flags'
+    flag_set {
+      expand_if_all_available: 'user_link_flags'
+      action: 'c++-link-executable'
+      action: 'c++-link-dynamic-library'
+      action: "c++-link-nodeps-dynamic-library"
+      flag_group {
+        iterate_over: 'user_link_flags'
+        flag: '%{user_link_flags}'
+      }
+    }
+  }
   feature {
     name: 'legacy_link_flags'
     flag_set {
@@ -935,9 +888,6 @@ cxx_builtin_include_directory: "C:\\botcode\\w\\ir\\run"
       action: 'c++-link-dynamic-library'
       action: "c++-link-nodeps-dynamic-library"
       action: 'c++-link-static-library'
-      action: 'c++-link-alwayslink-static-library'
-      action: 'c++-link-pic-static-library'
-      action: 'c++-link-alwayslink-pic-static-library'
       flag_group {
         flag: '@%{linker_param_file}'
       }
@@ -1142,6 +1092,65 @@ cxx_builtin_include_directory: "C:\\botcode\\w\\ir\\run"
       flag_group {
         iterate_over: 'unfiltered_compile_flags'
         flag: '%{unfiltered_compile_flags}'
+      }
+    }
+  }
+
+  feature {
+    name: 'compiler_output_flags'
+    flag_set {
+      action: 'assemble'
+      flag_group {
+        expand_if_all_available: 'output_file'
+        expand_if_none_available: 'output_assembly_file'
+        expand_if_none_available: 'output_preprocess_file'
+        flag: '/Fo%{output_file}'
+        flag: '/Zi'
+      }
+    }
+    flag_set {
+      action: 'preprocess-assemble'
+      action: 'c-compile'
+      action: 'c++-compile'
+      action: 'c++-header-parsing'
+      action: 'c++-header-preprocessing'
+      action: 'c++-module-compile'
+      action: 'c++-module-codegen'
+      flag_group {
+        expand_if_all_available: 'output_file'
+        expand_if_none_available: 'output_assembly_file'
+        expand_if_none_available: 'output_preprocess_file'
+        flag: '/Fo%{output_file}'
+      }
+      flag_group {
+        expand_if_all_available: 'output_file'
+        expand_if_all_available: 'output_assembly_file'
+        flag: '/Fa%{output_file}'
+      }
+      flag_group {
+        expand_if_all_available: 'output_file'
+        expand_if_all_available: 'output_preprocess_file'
+        flag: '/P'
+        flag: '/Fi%{output_file}'
+      }
+    }
+  }
+
+  feature {
+    name: 'compiler_input_flags'
+    flag_set {
+      action: 'assemble'
+      action: 'preprocess-assemble'
+      action: 'c-compile'
+      action: 'c++-compile'
+      action: 'c++-header-parsing'
+      action: 'c++-header-preprocessing'
+      action: 'c++-module-compile'
+      action: 'c++-module-codegen'
+      flag_group {
+        expand_if_all_available: 'source_file'
+        flag: '/c'
+        flag: '%{source_file}'
       }
     }
   }

--- a/configs/experimental/windows/0.1.0/bazel_experimental/README.md
+++ b/configs/experimental/windows/0.1.0/bazel_experimental/README.md
@@ -1,0 +1,3 @@
+This directory contains the toolchain config that works with 
+Bazel committed at a320e4460f35767da7fc8eb824ce1f4b304b5e0f.
+(Approximately dated Jun 13, 2018).


### PR DESCRIPTION
The version of Bazel that this toolchain was tested against was https://github.com/bazelbuild/bazel/commit/a320e4460f35767da7fc8eb824ce1f4b304b5e0f (Approx Jun 13, 2018)