### PR TITLE
Group repo dependencies into a macro.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,28 +13,40 @@
 # limitations under the License.
 workspace(name = "bazel_toolchains")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load(
     "//skylib:package_names.bzl",
     "jessie_package_names",
 )
-
-# Use http_archive rule instead of git_repository rule
-# https://docs.bazel.build/versions/master/be/workspace.html#git_repository
-http_archive(
-    name = "io_bazel_rules_docker",
-    sha256 = "5466861acd1e0a2afe745fdf383e5a4b5e06d19e571d49d252828cb2f2de13cb",
-    strip_prefix = "rules_docker-e325ffbf6508fe4cbaa3f5a0b09898f15e912d6a",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/e325ffbf6508fe4cbaa3f5a0b09898f15e912d6a.tar.gz"],
+load(
+    "@bazel_toolchains//repositories:repositories.bzl",
+    bazel_toolchains_repositories = "repositories",
 )
+
+bazel_toolchains_repositories()
 
 load(
     "@io_bazel_rules_docker//container:container.bzl",
-    "container_pull",
     container_repositories = "repositories",
+    "container_pull",
 )
 
 container_repositories()
+
+load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")
+
+go_rules_dependencies()
+
+go_register_toolchains()
+
+load(
+    "@distroless//package_manager:package_manager.bzl",
+    "package_manager_repositories",
+    "dpkg_list",
+    "dpkg_src",
+)
+
+# This is only needed by the old package manager.
+package_manager_repositories()
 
 container_pull(
     name = "debian8",
@@ -87,32 +99,6 @@ container_pull(
     tag = "16.04",
 )
 
-# io_bazel_rules_go is the dependency of container_test rules.
-http_archive(
-    name = "io_bazel_rules_go",
-    sha256 = "4b14d8dd31c6dbaf3ff871adcd03f28c3274e42abc855cb8fb4d01233c0154dc",
-    url = "https://github.com/bazelbuild/rules_go/releases/download/0.10.1/rules_go-0.10.1.tar.gz",
-)
-
-load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")
-
-go_rules_dependencies()
-
-go_register_toolchains()
-
-http_archive(
-    name = "base_images_docker",
-    sha256 = "89f1855aab28f6ebfbfba0dee46fa211dd36577ce45e7f01aef64733656dc51e",
-    strip_prefix = "base-images-docker-0d0080ed000d0ad00489d87e0016e05000a6937f",
-    urls = ["https://github.com/GoogleCloudPlatform/base-images-docker/archive/0d0080ed000d0ad00489d87e0016e05000a6937f.tar.gz"],
-)
-
-http_file(
-    name = "bazel_gpg",
-    sha256 = "30af2ca7abfb65987cd61802ca6e352aadc6129dfb5bfc9c81f16617bc3a4416",
-    url = "https://bazel.build/bazel-release.pub.gpg",
-)
-
 http_file(
     name = "debian_docker_gpg",
     sha256 = "1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570",
@@ -124,24 +110,6 @@ http_file(
     sha256 = "1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570",
     url = "https://download.docker.com/linux/ubuntu/gpg",
 )
-
-# Use http_archive rule instead of git_repository rule
-# https://docs.bazel.build/versions/master/be/workspace.html#git_repository
-http_archive(
-    name = "distroless",
-    sha256 = "44c5d3370df6983ef53cfc2347447c6595fea2d1951a1645660baf67657b8e23",
-    strip_prefix = "distroless-94b5126dbe06c2cb4dc74f7c9bfe6394b8e6e44c",
-    urls = ["https://github.com/GoogleCloudPlatform/distroless/archive/94b5126dbe06c2cb4dc74f7c9bfe6394b8e6e44c.tar.gz"],
-)
-
-load(
-    "@distroless//package_manager:package_manager.bzl",
-    "dpkg_list",
-    "dpkg_src",
-    "package_manager_repositories",
-)
-
-package_manager_repositories()
 
 # The Debian snapshot datetime to use.
 # This is kept up-to-date with https://github.com/GoogleCloudPlatform/base-images-docker/blob/master/WORKSPACE.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,8 +26,8 @@ bazel_toolchains_repositories()
 
 load(
     "@io_bazel_rules_docker//container:container.bzl",
-    container_repositories = "repositories",
     "container_pull",
+    container_repositories = "repositories",
 )
 
 container_repositories()
@@ -40,9 +40,9 @@ go_register_toolchains()
 
 load(
     "@distroless//package_manager:package_manager.bzl",
-    "package_manager_repositories",
     "dpkg_list",
     "dpkg_src",
+    "package_manager_repositories",
 )
 
 # This is only needed by the old package manager.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,7 +18,7 @@ load(
     "jessie_package_names",
 )
 load(
-    "@bazel_toolchains//repositories:repositories.bzl",
+    "//repositories:repositories.bzl",
     bazel_toolchains_repositories = "repositories",
 )
 

--- a/repositories/BUILD
+++ b/repositories/BUILD
@@ -1,0 +1,17 @@
+# Copyright 2016 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+licenses(["notice"])  # Apache 2.0
+
+package(default_visibility = ["//visibility:public"])

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -1,0 +1,62 @@
+# Copyright 2016 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Once recursive workspace is implemented in Bazel, this file should cease
+# to exist.
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def repositories():
+    """Download dependencies of bazel-toolchains."""
+    excludes = native.existing_rules().keys()
+
+    if "io_bazel_rules_docker" not in excludes:
+        http_archive(
+            name = "io_bazel_rules_docker",
+            sha256 = "5466861acd1e0a2afe745fdf383e5a4b5e06d19e571d49d252828cb2f2de13cb",
+            strip_prefix = "rules_docker-e325ffbf6508fe4cbaa3f5a0b09898f15e912d6a",
+            urls = ["https://github.com/bazelbuild/rules_docker/archive/e325ffbf6508fe4cbaa3f5a0b09898f15e912d6a.tar.gz"],
+        )
+
+    # io_bazel_rules_go is the dependency of container_test rules.
+    if "io_bazel_rules_go" not in excludes:
+        http_archive(
+            name = "io_bazel_rules_go",
+            sha256 = "4b14d8dd31c6dbaf3ff871adcd03f28c3274e42abc855cb8fb4d01233c0154dc",
+            url = "https://github.com/bazelbuild/rules_go/releases/download/0.10.1/rules_go-0.10.1.tar.gz",
+        )
+
+    if "base_images_docker" not in excludes:
+        http_archive(
+            name = "base_images_docker",
+            sha256 = "89f1855aab28f6ebfbfba0dee46fa211dd36577ce45e7f01aef64733656dc51e",
+            strip_prefix = "base-images-docker-0d0080ed000d0ad00489d87e0016e05000a6937f",
+            urls = ["https://github.com/GoogleCloudPlatform/base-images-docker/archive/0d0080ed000d0ad00489d87e0016e05000a6937f.tar.gz"],
+        )
+
+    if "distroless" not in excludes:
+        http_archive(
+            name = "distroless",
+            sha256 = "44c5d3370df6983ef53cfc2347447c6595fea2d1951a1645660baf67657b8e23",
+            strip_prefix = "distroless-94b5126dbe06c2cb4dc74f7c9bfe6394b8e6e44c",
+            urls = ["https://github.com/GoogleCloudPlatform/distroless/archive/94b5126dbe06c2cb4dc74f7c9bfe6394b8e6e44c.tar.gz"],
+        )
+
+    # Bazel gpg key necessary to install Bazel in the containers.
+    if "bazel_gpg" not in excludes:
+        native.http_file(
+            name = "bazel_gpg",
+            sha256 = "30af2ca7abfb65987cd61802ca6e352aadc6129dfb5bfc9c81f16617bc3a4416",
+            url = "https://bazel.build/bazel-release.pub.gpg",
+        )

--- a/rules/docker_config.bzl
+++ b/rules/docker_config.bzl
@@ -66,19 +66,12 @@ Add to your WORKSPACE file the following:
     sha256 = "<sha256>",
   )
 
-  http_archive(
-      name = "base_images_docker",
-      sha256 = "<sha256>",
-      strip_prefix = "base-images-docker-<latest_release>",
-      urls = ["https://github.com/GoogleCloudPlatform/base-images-docker/archive/<latest_release>.tar.gz"],
+  load(
+    "@bazel_toolchains//repositories:repositories.bzl",
+    bazel_toolchains_repositories = "repositories",
   )
 
-  http_archive(
-      name = "io_bazel_rules_docker",
-      sha256 = "<sha256>",
-      strip_prefix = "rules_docker-<latest_release>",
-      urls = ["https://github.com/bazelbuild/rules_docker/archive/<latest_release>.tar.gz"],
-  )
+  bazel_toolchains_repositories()
 
   load(
       "@io_bazel_rules_docker//container:container.bzl",

--- a/rules/docker_config.sh.tpl
+++ b/rules/docker_config.sh.tpl
@@ -23,7 +23,7 @@ main() {
   # Expand a tar file with the repo if needed
   %{EXPAND_REPO_CMD}
   # Call the script produced by the docker_build rule to load the image
-  ./%{LOAD_IMAGE_SH}
+  %{LOAD_IMAGE_SH}
   # Run the container image to build the config repos
   docker run --rm -e USER_ID="$(id -u)" -v $(pwd):/bazel-config -i %{IMAGE_NAME}
   # Create a tar file with all the config repos that were built

--- a/rules/docker_config.sh.tpl
+++ b/rules/docker_config.sh.tpl
@@ -23,7 +23,7 @@ main() {
   # Expand a tar file with the repo if needed
   %{EXPAND_REPO_CMD}
   # Call the script produced by the docker_build rule to load the image
-  %{LOAD_IMAGE_SH}
+  ./%{LOAD_IMAGE_SH}
   # Run the container image to build the config repos
   docker run --rm -e USER_ID="$(id -u)" -v $(pwd):/bazel-config -i %{IMAGE_NAME}
   # Create a tar file with all the config repos that were built


### PR DESCRIPTION
Also fix a bug when autoconfig target is located in the root BUILD file
of the workspace.