### PR TITLE
Changed install_pkgs output image tags to more sensical ones

### DIFF
--- a/test/container/BUILD
+++ b/test/container/BUILD
@@ -90,7 +90,7 @@ install_pkgs(
     name = "docker-prereq-test",
     image_tar = "@debian8//image",
     installables_tar = ":docker-prereq-packages.tar",
-    output_image_name = "docker-prereq-test:intermediate",
+    output_image_name = "docker-prereq-test:latest",
 )
 
 add_apt_key(
@@ -116,5 +116,5 @@ install_pkgs(
     name = "docker",
     image_tar = "@debian8//image",
     installables_tar = ":test-docker-packages.tar",
-    output_image_name = "docker:intermediate",
+    output_image_name = "docker:latest",
 )

--- a/test/container/BUILD
+++ b/test/container/BUILD
@@ -90,7 +90,7 @@ install_pkgs(
     name = "docker-prereq-test",
     image_tar = "@debian8//image",
     installables_tar = ":docker-prereq-packages.tar",
-    output_image_name = "bazel/test/container:docker-prereq-test",
+    output_image_name = "docker-prereq-test:intermediate",
 )
 
 add_apt_key(
@@ -116,5 +116,5 @@ install_pkgs(
     name = "docker",
     image_tar = "@debian8//image",
     installables_tar = ":test-docker-packages.tar",
-    output_image_name = "bazel/test/container:docker",
+    output_image_name = "docker:intermediate",
 )


### PR DESCRIPTION
Naming restrictions no longer apply because of new updates in
base-images-docker