### PR TITLE
removing java_runtime_suite

### DIFF
--- a/configs/debian8_clang/0.3.0/BUILD
+++ b/configs/debian8_clang/0.3.0/BUILD
@@ -14,13 +14,8 @@
 
 package(default_visibility = ["//visibility:public"])
 
-java_runtime_suite(
-    name = "jdk8",
-    default = ":jdk8-default",
-)
-
 java_runtime(
-    name = "jdk8-default",
+    name = "jdk8",
     srcs = [],
     java_home = "/usr/lib/jvm/java-8-openjdk-amd64",
 )

--- a/configs/ubuntu16_04_clang/1.0/BUILD
+++ b/configs/ubuntu16_04_clang/1.0/BUILD
@@ -14,13 +14,8 @@
 
 package(default_visibility = ["//visibility:public"])
 
-java_runtime_suite(
-    name = "jdk8",
-    default = ":jdk8-default",
-)
-
 java_runtime(
-    name = "jdk8-default",
+    name = "jdk8",
     srcs = [],
     java_home = "/usr/lib/jvm/java-8-openjdk-amd64",
 )


### PR DESCRIPTION
* java_runtime_suite is no longer supported:
https://github.com/bazelbuild/bazel/commit/6e0466f2c9d76d1ad9c1ee8ef7b3013e002765f1

* Tested that builds with bazel 0.14.0 and 0.15.0 work with javabase
pointing to java_runtime rule (and not to java_runtime_suite rule)