### PR TITLE
Remove java_runtime_suite from experimental Windows toolchains

### DIFF
--- a/configs/experimental/windows/0.1.0/BUILD
+++ b/configs/experimental/windows/0.1.0/BUILD
@@ -14,13 +14,8 @@
 
 package(default_visibility = ["//visibility:public"])
 
-java_runtime_suite(
-    name = "jdk8",
-    default = ":jdk8-default",
-)
-
 java_runtime(
-    name = "jdk8-default",
+    name = "jdk8",
     srcs = [],
     java_home = "C:/openjdk",
 )


### PR DESCRIPTION
java_runtime_suite has been removed from Bazel recently.

See https://github.com/bazelbuild/bazel-toolchains/pull/116 for a similar change.

Tested with a version of Bazel built at head, which previously failed complaining about the use of the java_runtime_suite rule.