### PR TITLE
Add platforms to experimental Windows config. 

### DIFF
--- a/configs/experimental/windows/0.1.0/BUILD
+++ b/configs/experimental/windows/0.1.0/BUILD
@@ -19,3 +19,89 @@ java_runtime(
     srcs = [],
     java_home = "C:/openjdk",
 )
+
+# Below are a number of almost identical Windows platforms. It is desirable to
+# be able to vary the "Pool" property at runtime, but since it has to be baked
+# into this BUILD file it's not possible. As a compromise, provide one platform
+# for each of the default pool, and three generic Windows pools.
+
+# RBE Windows 1803 image that uses "default" pool.
+platform(
+    name = "rbe_windows",
+    constraint_values = [
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//platforms:windows",
+    ],
+    remote_execution_properties = """
+        properties:{
+          name:"container-image"
+          value:"docker://gcr.io/rbe-windows-test-images/windowstest@sha256:81b032d1496868a5b415973e33a0fa4076e5136dc9dc59ba816dde1f3716db80"
+        }
+        properties:{
+          name: "OSFamily" value: "Windows"
+        }
+        """,
+)
+
+# RBE Windows 1803 image that uses "windows_1" pool.
+platform(
+    name = "rbe_windows_1",
+    constraint_values = [
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//platforms:windows",
+    ],
+    remote_execution_properties = """
+        properties:{
+          name:"container-image"
+          value:"docker://gcr.io/rbe-windows-test-images/windowstest@sha256:81b032d1496868a5b415973e33a0fa4076e5136dc9dc59ba816dde1f3716db80"
+        }
+        properties:{
+          name: "OSFamily" value: "Windows"
+        }
+        properties:{
+          name: "Pool" value: "windows_1"
+        }
+        """,
+)
+
+# RBE Windows 1803 image that uses "windows_2" pool.
+platform(
+    name = "rbe_windows_2",
+    constraint_values = [
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//platforms:windows",
+    ],
+    remote_execution_properties = """
+        properties:{
+          name:"container-image"
+          value:"docker://gcr.io/rbe-windows-test-images/windowstest@sha256:81b032d1496868a5b415973e33a0fa4076e5136dc9dc59ba816dde1f3716db80"
+        }
+        properties:{
+          name: "OSFamily" value: "Windows"
+        }
+        properties:{
+          name: "Pool" value: "windows_2"
+        }
+        """,
+)
+
+# RBE Windows 1803 image that uses "windows_3" pool.
+platform(
+    name = "rbe_windows_3",
+    constraint_values = [
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//platforms:windows",
+    ],
+    remote_execution_properties = """
+        properties:{
+          name:"container-image"
+          value:"docker://gcr.io/rbe-windows-test-images/windowstest@sha256:81b032d1496868a5b415973e33a0fa4076e5136dc9dc59ba816dde1f3716db80"
+        }
+        properties:{
+          name: "OSFamily" value: "Windows"
+        }
+        properties:{
+          name: "Pool" value: "windows_3"
+        }
+        """,
+)


### PR DESCRIPTION
We want to vary the Pool property at runtime, but can't in this model, so I provided a few platforms with alternative values for the Pool property for now. This is mostly a convenience for experimentation and we can make this better later.