### PR TITLE
Revert "Switch to marketplace.gcr.io registry."

### DIFF
--- a/bazelrc/bazel-0.10.0.bazelrc
+++ b/bazelrc/bazel-0.10.0.bazelrc
@@ -33,7 +33,7 @@ build:remote --jobs=50
 build:remote --host_javabase=@bazel_toolchains//configs/debian8_clang/0.3.0:jdk8
 build:remote --javabase=@bazel_toolchains//configs/debian8_clang/0.3.0:jdk8
 build:remote --crosstool_top=@bazel_toolchains//configs/debian8_clang/0.3.0/bazel_0.10.0:toolchain
-build:remote --experimental_remote_platform_override='properties:{ name:"container-image" value:"docker://marketplace.gcr.io/google/rbe-debian8@sha256:d84a7de5175a22505209f56b02f1da20ccec64880da09ee38eaef3670fbd2a56" }'
+build:remote --experimental_remote_platform_override='properties:{ name:"container-image" value:"docker://gcr.io/cloud-marketplace/google/rbe-debian8@sha256:d84a7de5175a22505209f56b02f1da20ccec64880da09ee38eaef3670fbd2a56" }'
 
 # Set various strategies so that all actions execute remotely. Mixing remote
 # and local execution will lead to errors unless the toolchain and remote

--- a/bazelrc/bazel-0.12.0.bazelrc
+++ b/bazelrc/bazel-0.12.0.bazelrc
@@ -33,7 +33,7 @@ build:remote --jobs=50
 build:remote --host_javabase=@bazel_toolchains//configs/debian8_clang/0.3.0:jdk8
 build:remote --javabase=@bazel_toolchains//configs/debian8_clang/0.3.0:jdk8
 build:remote --crosstool_top=@bazel_toolchains//configs/debian8_clang/0.3.0/bazel_0.12.0/default:toolchain
-build:remote --experimental_remote_platform_override='properties:{ name:"container-image" value:"docker://marketplace.gcr.io/google/rbe-debian8@sha256:d84a7de5175a22505209f56b02f1da20ccec64880da09ee38eaef3670fbd2a56" }'
+build:remote --experimental_remote_platform_override='properties:{ name:"container-image" value:"docker://gcr.io/cloud-marketplace/google/rbe-debian8@sha256:d84a7de5175a22505209f56b02f1da20ccec64880da09ee38eaef3670fbd2a56" }'
 
 # Set various strategies so that all actions execute remotely. Mixing remote
 # and local execution will lead to errors unless the toolchain and remote

--- a/bazelrc/bazel-0.13.0.bazelrc
+++ b/bazelrc/bazel-0.13.0.bazelrc
@@ -33,7 +33,7 @@ build:remote --jobs=50
 build:remote --host_javabase=@bazel_toolchains//configs/ubuntu16_04_clang/1.0:jdk8
 build:remote --javabase=@bazel_toolchains//configs/ubuntu16_04_clang/1.0:jdk8
 build:remote --crosstool_top=@bazel_toolchains//configs/ubuntu16_04_clang/1.0/bazel_0.13.0/default:toolchain
-build:remote --experimental_remote_platform_override='properties:{ name:"container-image" value:"docker://marketplace.gcr.io/google/rbe-ubuntu16-04@sha256:59bf0e191a6b5cc1ab62c2224c810681d1326bad5a27b1d36c9f40113e79da7f" }'
+build:remote --experimental_remote_platform_override='properties:{ name:"container-image" value:"docker://gcr.io/cloud-marketplace/google/rbe-ubuntu16-04@sha256:59bf0e191a6b5cc1ab62c2224c810681d1326bad5a27b1d36c9f40113e79da7f" }'
 
 # Set various strategies so that all actions execute remotely. Mixing remote
 # and local execution will lead to errors unless the toolchain and remote

--- a/bazelrc/bazel-0.14.1.bazelrc
+++ b/bazelrc/bazel-0.14.1.bazelrc
@@ -35,7 +35,7 @@ build:remote --jobs=50
 build:remote --host_javabase=@bazel_toolchains//configs/ubuntu16_04_clang/1.0:jdk8
 build:remote --javabase=@bazel_toolchains//configs/ubuntu16_04_clang/1.0:jdk8
 build:remote --crosstool_top=@bazel_toolchains//configs/ubuntu16_04_clang/1.0/bazel_0.14.1/default:toolchain
-build:remote --experimental_remote_platform_override='properties:{ name:"container-image" value:"docker://marketplace.gcr.io/google/rbe-ubuntu16-04@sha256:59bf0e191a6b5cc1ab62c2224c810681d1326bad5a27b1d36c9f40113e79da7f" }'
+build:remote --experimental_remote_platform_override='properties:{ name:"container-image" value:"docker://gcr.io/cloud-marketplace/google/rbe-ubuntu16-04@sha256:59bf0e191a6b5cc1ab62c2224c810681d1326bad5a27b1d36c9f40113e79da7f" }'
 build:remote --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:remote --extra_toolchains=@bazel_toolchains//configs/ubuntu16_04_clang/1.0/bazel_0.14.1/cpp:cc-toolchain-clang-x86_64-default
 build:remote --extra_execution_platforms=@bazel_toolchains//configs/ubuntu16_04_clang/1.0:rbe_ubuntu1604
@@ -100,7 +100,7 @@ build:results-local --bes_results_url="https://source.cloud.google.com/results/i
 build:docker-sandbox --host_javabase=@bazel_toolchains//configs/ubuntu16_04_clang/1.0:jdk8
 build:docker-sandbox --javabase=@bazel_toolchains//configs/ubuntu16_04_clang/1.0:jdk8
 build:docker-sandbox --crosstool_top=@bazel_toolchains//configs/ubuntu16_04_clang/1.0/bazel_0.14.1/default:toolchain
-build:docker-sandbox --experimental_docker_image=marketplace.gcr.io/google/rbe-ubuntu16-04@sha256:59bf0e191a6b5cc1ab62c2224c810681d1326bad5a27b1d36c9f40113e79da7f
+build:docker-sandbox --experimental_docker_image=gcr.io/cloud-marketplace/google/rbe-ubuntu16-04@sha256:59bf0e191a6b5cc1ab62c2224c810681d1326bad5a27b1d36c9f40113e79da7f
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker
 build:docker-sandbox --strategy=Closure=docker

--- a/bazelrc/bazel-0.15.0.bazelrc
+++ b/bazelrc/bazel-0.15.0.bazelrc
@@ -115,7 +115,7 @@ build:results-local --bes_results_url="https://source.cloud.google.com/results/i
 build:docker-sandbox --host_javabase=@bazel_toolchains//configs/ubuntu16_04_clang/1.0:jdk8
 build:docker-sandbox --javabase=@bazel_toolchains//configs/ubuntu16_04_clang/1.0:jdk8
 build:docker-sandbox --crosstool_top=@bazel_toolchains//configs/ubuntu16_04_clang/1.0/bazel_0.15.0/default:toolchain
-build:docker-sandbox --experimental_docker_image=marketplace.gcr.io/google/rbe-ubuntu16-04@sha256:59bf0e191a6b5cc1ab62c2224c810681d1326bad5a27b1d36c9f40113e79da7f
+build:docker-sandbox --experimental_docker_image=gcr.io/cloud-marketplace/google/rbe-ubuntu16-04@sha256:59bf0e191a6b5cc1ab62c2224c810681d1326bad5a27b1d36c9f40113e79da7f
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker
 build:docker-sandbox --strategy=Closure=docker

--- a/bazelrc/bazel-0.9.0.bazelrc
+++ b/bazelrc/bazel-0.9.0.bazelrc
@@ -33,7 +33,7 @@ build:remote --jobs=50
 build:remote --host_javabase=@bazel_toolchains//configs/debian8_clang/0.2.0:jdk8
 build:remote --javabase=@bazel_toolchains//configs/debian8_clang/0.2.0:jdk8
 build:remote --crosstool_top=@bazel_toolchains//configs/debian8_clang/0.2.0/bazel_0.9.0:toolchain
-build:remote --experimental_remote_platform_override='properties:{ name:"container-image" value:"docker://marketplace.gcr.io/google/rbe-debian8@sha256:496193842f61c9494be68bd624e47c74d706cabf19a693c4653ffe96a97e43e3" }'
+build:remote --experimental_remote_platform_override='properties:{ name:"container-image" value:"docker://gcr.io/cloud-marketplace/google/rbe-debian8@sha256:496193842f61c9494be68bd624e47c74d706cabf19a693c4653ffe96a97e43e3" }'
 
 # Set various strategies so that all actions execute remotely. Mixing remote
 # and local execution will lead to errors unless the toolchain and remote

--- a/configs/debian8_clang/0.2.0/bazel_0.10.0/METADATA
+++ b/configs/debian8_clang/0.2.0/bazel_0.10.0/METADATA
@@ -1,1 +1,1 @@
-marketplace.gcr.io/google/clang-debian8@sha256:e57978199c9eb156bd7f63773387f3a238adf61acd71c4942ad91da50b4f241f
+gcr.io/cloud-marketplace/google/clang-debian8@sha256:e57978199c9eb156bd7f63773387f3a238adf61acd71c4942ad91da50b4f241f

--- a/configs/debian8_clang/0.2.0/bazel_0.8.0/METADATA
+++ b/configs/debian8_clang/0.2.0/bazel_0.8.0/METADATA
@@ -1,1 +1,1 @@
-marketplace.gcr.io/google/clang-debian8@sha256:0945e882b51e3f9dc1d8944a49f361573ef8e522588eb94263f8e6e094453435
+gcr.io/cloud-marketplace/google/clang-debian8@sha256:0945e882b51e3f9dc1d8944a49f361573ef8e522588eb94263f8e6e094453435

--- a/configs/debian8_clang/0.2.0/bazel_0.9.0/METADATA
+++ b/configs/debian8_clang/0.2.0/bazel_0.9.0/METADATA
@@ -1,1 +1,1 @@
-marketplace.gcr.io/google/clang-debian8@sha256:62ad7c44890792fdb2c2593fc24cfab7132e3a112d55bd453e09387906ae5e2f
+gcr.io/cloud-marketplace/google/clang-debian8@sha256:62ad7c44890792fdb2c2593fc24cfab7132e3a112d55bd453e09387906ae5e2f

--- a/configs/debian8_clang/0.2.0/toolchain.bazelrc
+++ b/configs/debian8_clang/0.2.0/toolchain.bazelrc
@@ -2,4 +2,4 @@
 build:remote --host_javabase=@bazel_toolchains//configs/debian8_clang/0.2.0:jdk8
 build:remote --javabase=@bazel_toolchains//configs/debian8_clang/0.2.0:jdk8
 build:remote --crosstool_top=@bazel_toolchains//configs/debian8_clang/0.2.0/bazel_0.10.0:toolchain
-build:remote --experimental_remote_platform_override='properties:{ name:"container-image" value:"docker://marketplace.gcr.io/google/rbe-debian8@sha256:496193842f61c9494be68bd624e47c74d706cabf19a693c4653ffe96a97e43e3" }'
+build:remote --experimental_remote_platform_override='properties:{ name:"container-image" value:"docker://gcr.io/cloud-marketplace/google/rbe-debian8@sha256:496193842f61c9494be68bd624e47c74d706cabf19a693c4653ffe96a97e43e3" }'

--- a/configs/debian8_clang/0.3.0/BUILD
+++ b/configs/debian8_clang/0.3.0/BUILD
@@ -40,7 +40,7 @@ platform(
     remote_execution_properties = """
           properties: {
             name: "container-image"
-            value:"docker://marketplace.gcr.io/google/rbe-debian8@sha256:0d5db936f8fa04638ca31e4fc117415068dca43dc343d605c0db2a15f433a327"
+            value:"docker://gcr.io/cloud-marketplace/google/rbe-debian8@sha256:0d5db936f8fa04638ca31e4fc117415068dca43dc343d605c0db2a15f433a327"
          }
          """,
 )

--- a/configs/debian8_clang/0.3.0/bazel_0.10.0/METADATA
+++ b/configs/debian8_clang/0.3.0/bazel_0.10.0/METADATA
@@ -1,1 +1,1 @@
-marketplace.gcr.io/google/clang-debian8@sha256:ac3b1fdc22c0f2b95abe67f2daf33788425fab52d4e6845900bfe1a42443098f
+gcr.io/cloud-marketplace/google/clang-debian8@sha256:ac3b1fdc22c0f2b95abe67f2daf33788425fab52d4e6845900bfe1a42443098f

--- a/configs/debian8_clang/0.3.0/bazel_0.11.0/msan/METADATA
+++ b/configs/debian8_clang/0.3.0/bazel_0.11.0/msan/METADATA
@@ -1,1 +1,1 @@
-marketplace.gcr.io/google/clang-debian8@sha256:ac3b1fdc22c0f2b95abe67f2daf33788425fab52d4e6845900bfe1a42443098f
+gcr.io/cloud-marketplace/google/clang-debian8@sha256:ac3b1fdc22c0f2b95abe67f2daf33788425fab52d4e6845900bfe1a42443098f

--- a/configs/debian8_clang/0.3.0/bazel_0.12.0/default/METADATA
+++ b/configs/debian8_clang/0.3.0/bazel_0.12.0/default/METADATA
@@ -1,1 +1,1 @@
-marketplace.gcr.io/google/clang-debian8@sha256:213da2494bb763f55363213db45d9bfa5eb906039fc02e6cb2e6637dc4917caf
+gcr.io/cloud-marketplace/google/clang-debian8@sha256:213da2494bb763f55363213db45d9bfa5eb906039fc02e6cb2e6637dc4917caf

--- a/configs/debian8_clang/0.3.0/bazel_0.12.0/msan/METADATA
+++ b/configs/debian8_clang/0.3.0/bazel_0.12.0/msan/METADATA
@@ -1,1 +1,1 @@
-marketplace.gcr.io/google/clang-debian8@sha256:213da2494bb763f55363213db45d9bfa5eb906039fc02e6cb2e6637dc4917caf
+gcr.io/cloud-marketplace/google/clang-debian8@sha256:213da2494bb763f55363213db45d9bfa5eb906039fc02e6cb2e6637dc4917caf

--- a/configs/debian8_clang/0.3.0/bazel_0.13.0/default/METADATA
+++ b/configs/debian8_clang/0.3.0/bazel_0.13.0/default/METADATA
@@ -1,1 +1,1 @@
-marketplace.gcr.io/google/clang-debian8@sha256:213da2494bb763f55363213db45d9bfa5eb906039fc02e6cb2e6637dc4917caf
+gcr.io/cloud-marketplace/google/clang-debian8@sha256:213da2494bb763f55363213db45d9bfa5eb906039fc02e6cb2e6637dc4917caf

--- a/configs/debian8_clang/0.3.0/bazel_0.13.0/msan/METADATA
+++ b/configs/debian8_clang/0.3.0/bazel_0.13.0/msan/METADATA
@@ -1,1 +1,1 @@
-marketplace.gcr.io/google/clang-debian8@sha256:213da2494bb763f55363213db45d9bfa5eb906039fc02e6cb2e6637dc4917caf
+gcr.io/cloud-marketplace/google/clang-debian8@sha256:213da2494bb763f55363213db45d9bfa5eb906039fc02e6cb2e6637dc4917caf

--- a/configs/debian8_clang/0.3.0/bazel_0.14.1/default/METADATA
+++ b/configs/debian8_clang/0.3.0/bazel_0.14.1/default/METADATA
@@ -1,1 +1,1 @@
-marketplace.gcr.io/google/clang-debian8@sha256:8bb65bf0a0da8be48bbac07ebe743805f3dc5259203e19517098162bd23a768f
+gcr.io/cloud-marketplace/google/clang-debian8@sha256:8bb65bf0a0da8be48bbac07ebe743805f3dc5259203e19517098162bd23a768f

--- a/configs/debian8_clang/0.3.0/bazel_0.14.1/msan/METADATA
+++ b/configs/debian8_clang/0.3.0/bazel_0.14.1/msan/METADATA
@@ -1,1 +1,1 @@
-marketplace.gcr.io/google/clang-debian8@sha256:8bb65bf0a0da8be48bbac07ebe743805f3dc5259203e19517098162bd23a768f
+gcr.io/cloud-marketplace/google/clang-debian8@sha256:8bb65bf0a0da8be48bbac07ebe743805f3dc5259203e19517098162bd23a768f

--- a/configs/debian8_clang/0.3.0/bazel_0.15.0/default/METADATA
+++ b/configs/debian8_clang/0.3.0/bazel_0.15.0/default/METADATA
@@ -1,1 +1,1 @@
-marketplace.gcr.io/google/clang-debian8@sha256:8bb65bf0a0da8be48bbac07ebe743805f3dc5259203e19517098162bd23a768f
+gcr.io/cloud-marketplace/google/clang-debian8@sha256:8bb65bf0a0da8be48bbac07ebe743805f3dc5259203e19517098162bd23a768f

--- a/configs/debian8_clang/0.3.0/bazel_0.15.0/msan/METADATA
+++ b/configs/debian8_clang/0.3.0/bazel_0.15.0/msan/METADATA
@@ -1,1 +1,1 @@
-marketplace.gcr.io/google/clang-debian8@sha256:8bb65bf0a0da8be48bbac07ebe743805f3dc5259203e19517098162bd23a768f
+gcr.io/cloud-marketplace/google/clang-debian8@sha256:8bb65bf0a0da8be48bbac07ebe743805f3dc5259203e19517098162bd23a768f

--- a/configs/debian8_clang/BUILD
+++ b/configs/debian8_clang/BUILD
@@ -52,7 +52,7 @@ docker_toolchain_autoconfig(
 )
 
 # Created on 2018.01.10
-# Container: marketplace.gcr.io/google/clang-debian8@sha256:62ad7c44890792fdb2c2593fc24cfab7132e3a112d55bd453e09387906ae5e2f
+# Container: gcr.io/cloud-marketplace/google/clang-debian8@sha256:62ad7c44890792fdb2c2593fc24cfab7132e3a112d55bd453e09387906ae5e2f
 docker_toolchain_autoconfig(
     name = "debian8-clang-0.2.0-bazel_0.9.0-autoconfig",
     additional_repos = debian8_clang_default_repos(),
@@ -66,7 +66,7 @@ docker_toolchain_autoconfig(
 )
 
 # Created on 2018.02.05
-# Container: marketplace.gcr.io/google/clang-debian8@sha256:e57978199c9eb156bd7f63773387f3a238adf61acd71c4942ad91da50b4f241f
+# Container: gcr.io/cloud-marketplace/google/clang-debian8@sha256:e57978199c9eb156bd7f63773387f3a238adf61acd71c4942ad91da50b4f241f
 docker_toolchain_autoconfig(
     name = "debian8-clang-0.2.0-bazel_0.10.0-autoconfig",
     additional_repos = debian8_clang_default_repos(),
@@ -80,7 +80,7 @@ docker_toolchain_autoconfig(
 )
 
 # Created on 2018.02.13
-# Container: marketplace.gcr.io/google/clang-debian8@sha256:ac3b1fdc22c0f2b95abe67f2daf33788425fab52d4e6845900bfe1a42443098f
+# Container: gcr.io/cloud-marketplace/google/clang-debian8@sha256:ac3b1fdc22c0f2b95abe67f2daf33788425fab52d4e6845900bfe1a42443098f
 docker_toolchain_autoconfig(
     name = "debian8-clang-0.3.0-bazel_0.10.0-autoconfig",
     additional_repos = debian8_clang_default_repos(),
@@ -94,7 +94,7 @@ docker_toolchain_autoconfig(
 )
 
 # Created on 2018.04.06
-# Container: marketplace.gcr.io/google/clang-debian8@sha256:ac3b1fdc22c0f2b95abe67f2daf33788425fab52d4e6845900bfe1a42443098f
+# Container: gcr.io/cloud-marketplace/google/clang-debian8@sha256:ac3b1fdc22c0f2b95abe67f2daf33788425fab52d4e6845900bfe1a42443098f
 docker_toolchain_autoconfig(
     name = "msan-debian8-clang-0.3.0-bazel_0.11.0-autoconfig",
     additional_repos = debian8_clang_default_repos(),
@@ -110,7 +110,7 @@ docker_toolchain_autoconfig(
 )
 
 # Created on 2018.04.23
-# Container: marketplace.gcr.io/google/clang-debian8@sha256:213da2494bb763f55363213db45d9bfa5eb906039fc02e6cb2e6637dc4917caf
+# Container: gcr.io/cloud-marketplace/google/clang-debian8@sha256:213da2494bb763f55363213db45d9bfa5eb906039fc02e6cb2e6637dc4917caf
 docker_toolchain_autoconfig(
     name = "debian8-clang-0.3.0-bazel_0.12.0-autoconfig",
     additional_repos = debian8_clang_default_repos(),
@@ -124,7 +124,7 @@ docker_toolchain_autoconfig(
 )
 
 # Created on 2018.04.23
-# Container: marketplace.gcr.io/google/clang-debian8@sha256:213da2494bb763f55363213db45d9bfa5eb906039fc02e6cb2e6637dc4917caf
+# Container: gcr.io/cloud-marketplace/google/clang-debian8@sha256:213da2494bb763f55363213db45d9bfa5eb906039fc02e6cb2e6637dc4917caf
 docker_toolchain_autoconfig(
     name = "msan-debian8-clang-0.3.0-bazel_0.12.0-autoconfig",
     additional_repos = debian8_clang_default_repos(),
@@ -140,7 +140,7 @@ docker_toolchain_autoconfig(
 )
 
 # Created on 2018.04.30
-# Container: marketplace.gcr.io/google/clang-debian8@sha256:213da2494bb763f55363213db45d9bfa5eb906039fc02e6cb2e6637dc4917caf
+# Container: gcr.io/cloud-marketplace/google/clang-debian8@sha256:213da2494bb763f55363213db45d9bfa5eb906039fc02e6cb2e6637dc4917caf
 docker_toolchain_autoconfig(
     name = "debian8-clang-0.3.0-bazel_0.13.0-autoconfig",
     additional_repos = debian8_clang_default_repos(),
@@ -154,7 +154,7 @@ docker_toolchain_autoconfig(
 )
 
 # Created on 2018.04.30
-# Container: marketplace.gcr.io/google/clang-debian8@sha256:213da2494bb763f55363213db45d9bfa5eb906039fc02e6cb2e6637dc4917caf
+# Container: gcr.io/cloud-marketplace/google/clang-debian8@sha256:213da2494bb763f55363213db45d9bfa5eb906039fc02e6cb2e6637dc4917caf
 docker_toolchain_autoconfig(
     name = "msan-debian8-clang-0.3.0-bazel_0.13.0-autoconfig",
     additional_repos = debian8_clang_default_repos(),
@@ -170,7 +170,7 @@ docker_toolchain_autoconfig(
 )
 
 # Created on 2018.06.08
-# Container: marketplace.gcr.io/google/clang-debian8@sha256:8bb65bf0a0da8be48bbac07ebe743805f3dc5259203e19517098162bd23a768f
+# Container: gcr.io/cloud-marketplace/google/clang-debian8@sha256:8bb65bf0a0da8be48bbac07ebe743805f3dc5259203e19517098162bd23a768f
 docker_toolchain_autoconfig(
     name = "debian8-clang-0.3.0-bazel_0.14.1-autoconfig",
     additional_repos = debian8_clang_default_repos(),
@@ -184,7 +184,7 @@ docker_toolchain_autoconfig(
 )
 
 # Created on 2018.06.08
-# Container: marketplace.gcr.io/google/clang-debian8@sha256:8bb65bf0a0da8be48bbac07ebe743805f3dc5259203e19517098162bd23a768f
+# Container: gcr.io/cloud-marketplace/google/clang-debian8@sha256:8bb65bf0a0da8be48bbac07ebe743805f3dc5259203e19517098162bd23a768f
 docker_toolchain_autoconfig(
     name = "msan-debian8-clang-0.3.0-bazel_0.14.1-autoconfig",
     additional_repos = debian8_clang_default_repos(),
@@ -200,7 +200,7 @@ docker_toolchain_autoconfig(
 )
 
 # Created on 2018.06.27
-# Container: marketplace.gcr.io/google/clang-debian8@sha256:8bb65bf0a0da8be48bbac07ebe743805f3dc5259203e19517098162bd23a768f
+# Container: gcr.io/cloud-marketplace/google/clang-debian8@sha256:8bb65bf0a0da8be48bbac07ebe743805f3dc5259203e19517098162bd23a768f
 docker_toolchain_autoconfig(
     name = "debian8-clang-0.3.0-bazel_0.15.0-autoconfig",
     additional_repos = debian8_clang_default_repos(),
@@ -214,7 +214,7 @@ docker_toolchain_autoconfig(
 )
 
 # Created on 2018.06.27
-# Container: marketplace.gcr.io/google/clang-debian8@sha256:8bb65bf0a0da8be48bbac07ebe743805f3dc5259203e19517098162bd23a768f
+# Container: gcr.io/cloud-marketplace/google/clang-debian8@sha256:8bb65bf0a0da8be48bbac07ebe743805f3dc5259203e19517098162bd23a768f
 docker_toolchain_autoconfig(
     name = "msan-debian8-clang-0.3.0-bazel_0.15.0-autoconfig",
     additional_repos = debian8_clang_default_repos(),

--- a/configs/experimental/BUILD
+++ b/configs/experimental/BUILD
@@ -26,7 +26,7 @@ load(
 )
 
 # Created on 2018.02.13
-# Container: marketplace.gcr.io/google/clang-debian8@sha256:ac3b1fdc22c0f2b95abe67f2daf33788425fab52d4e6845900bfe1a42443098f
+# Container: gcr.io/cloud-marketplace/google/clang-debian8@sha256:ac3b1fdc22c0f2b95abe67f2daf33788425fab52d4e6845900bfe1a42443098f
 # This config is still experimental
 # TODO(ngiraldo): remove experimental comment once this has been tested
 docker_toolchain_autoconfig(

--- a/configs/experimental/debian8_clang/0.2.0/bazel_0.9.0/msan/METADATA
+++ b/configs/experimental/debian8_clang/0.2.0/bazel_0.9.0/msan/METADATA
@@ -1,1 +1,1 @@
-marketplace.gcr.io/google/clang-debian8@sha256:62ad7c44890792fdb2c2593fc24cfab7132e3a112d55bd453e09387906ae5e2f
+gcr.io/cloud-marketplace/google/clang-debian8@sha256:62ad7c44890792fdb2c2593fc24cfab7132e3a112d55bd453e09387906ae5e2f

--- a/configs/experimental/debian8_clang/0.2.0/bazel_0.9.0/ubsan/METADATA
+++ b/configs/experimental/debian8_clang/0.2.0/bazel_0.9.0/ubsan/METADATA
@@ -1,1 +1,1 @@
-marketplace.gcr.io/google/clang-debian8@sha256:62ad7c44890792fdb2c2593fc24cfab7132e3a112d55bd453e09387906ae5e2f
+gcr.io/cloud-marketplace/google/clang-debian8@sha256:62ad7c44890792fdb2c2593fc24cfab7132e3a112d55bd453e09387906ae5e2f

--- a/configs/experimental/debian8_clang/0.3.0/bazel_0.10.0/msan/METADATA
+++ b/configs/experimental/debian8_clang/0.3.0/bazel_0.10.0/msan/METADATA
@@ -1,1 +1,1 @@
-marketplace.gcr.io/google/clang-debian8@sha256:ac3b1fdc22c0f2b95abe67f2daf33788425fab52d4e6845900bfe1a42443098f
+gcr.io/cloud-marketplace/google/clang-debian8@sha256:ac3b1fdc22c0f2b95abe67f2daf33788425fab52d4e6845900bfe1a42443098f

--- a/configs/experimental/debian8_clang/0.3.0/bazel_0.10.0/ubsan/METADATA
+++ b/configs/experimental/debian8_clang/0.3.0/bazel_0.10.0/ubsan/METADATA
@@ -1,1 +1,1 @@
-marketplace.gcr.io/google/clang-debian8@sha256:ac3b1fdc22c0f2b95abe67f2daf33788425fab52d4e6845900bfe1a42443098f
+gcr.io/cloud-marketplace/google/clang-debian8@sha256:ac3b1fdc22c0f2b95abe67f2daf33788425fab52d4e6845900bfe1a42443098f

--- a/configs/experimental/debian8_clang/0.3.0/bazel_0.12.0/ubsan/METADATA
+++ b/configs/experimental/debian8_clang/0.3.0/bazel_0.12.0/ubsan/METADATA
@@ -1,1 +1,1 @@
-marketplace.gcr.io/google/clang-debian8@sha256:213da2494bb763f55363213db45d9bfa5eb906039fc02e6cb2e6637dc4917caf
+gcr.io/cloud-marketplace/google/clang-debian8@sha256:213da2494bb763f55363213db45d9bfa5eb906039fc02e6cb2e6637dc4917caf

--- a/configs/experimental/ubuntu16_04_clang/1.0/bazel_0.13.0/ubsan/METADATA
+++ b/configs/experimental/ubuntu16_04_clang/1.0/bazel_0.13.0/ubsan/METADATA
@@ -1,1 +1,1 @@
-marketplace.gcr.io/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7
+gcr.io/cloud-marketplace/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7

--- a/configs/experimental/ubuntu16_04_clang/1.0/bazel_0.14.1/ubsan/METADATA
+++ b/configs/experimental/ubuntu16_04_clang/1.0/bazel_0.14.1/ubsan/METADATA
@@ -1,1 +1,1 @@
-marketplace.gcr.io/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7
+gcr.io/cloud-marketplace/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7

--- a/configs/experimental/ubuntu16_04_clang/1.0/bazel_0.15.0/ubsan/METADATA
+++ b/configs/experimental/ubuntu16_04_clang/1.0/bazel_0.15.0/ubsan/METADATA
@@ -1,1 +1,1 @@
-marketplace.gcr.io/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7
+gcr.io/cloud-marketplace/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7

--- a/configs/ubuntu16_04_clang/1.0/BUILD
+++ b/configs/ubuntu16_04_clang/1.0/BUILD
@@ -40,7 +40,7 @@ platform(
     remote_execution_properties = """
           properties: {
             name: "container-image"
-            value:"docker://marketplace.gcr.io/google/rbe-ubuntu16-04@sha256:59bf0e191a6b5cc1ab62c2224c810681d1326bad5a27b1d36c9f40113e79da7f"
+            value:"docker://gcr.io/cloud-marketplace/google/rbe-ubuntu16-04@sha256:59bf0e191a6b5cc1ab62c2224c810681d1326bad5a27b1d36c9f40113e79da7f"
          }
          """,
 )

--- a/configs/ubuntu16_04_clang/1.0/bazel_0.13.0/default/METADATA
+++ b/configs/ubuntu16_04_clang/1.0/bazel_0.13.0/default/METADATA
@@ -1,1 +1,1 @@
-marketplace.gcr.io/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7
+gcr.io/cloud-marketplace/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7

--- a/configs/ubuntu16_04_clang/1.0/bazel_0.13.0/msan/METADATA
+++ b/configs/ubuntu16_04_clang/1.0/bazel_0.13.0/msan/METADATA
@@ -1,1 +1,1 @@
-marketplace.gcr.io/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7
+gcr.io/cloud-marketplace/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7

--- a/configs/ubuntu16_04_clang/1.0/bazel_0.14.1/default/METADATA
+++ b/configs/ubuntu16_04_clang/1.0/bazel_0.14.1/default/METADATA
@@ -1,1 +1,1 @@
-marketplace.gcr.io/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7
+gcr.io/cloud-marketplace/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7

--- a/configs/ubuntu16_04_clang/1.0/bazel_0.14.1/msan/METADATA
+++ b/configs/ubuntu16_04_clang/1.0/bazel_0.14.1/msan/METADATA
@@ -1,1 +1,1 @@
- marketplace.gcr.io/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7
+ gcr.io/cloud-marketplace/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7

--- a/configs/ubuntu16_04_clang/1.0/bazel_0.15.0/default/METADATA
+++ b/configs/ubuntu16_04_clang/1.0/bazel_0.15.0/default/METADATA
@@ -1,1 +1,1 @@
-marketplace.gcr.io/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7
+gcr.io/cloud-marketplace/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7

--- a/configs/ubuntu16_04_clang/1.0/bazel_0.15.0/msan/METADATA
+++ b/configs/ubuntu16_04_clang/1.0/bazel_0.15.0/msan/METADATA
@@ -1,1 +1,1 @@
-marketplace.gcr.io/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7
+gcr.io/cloud-marketplace/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7

--- a/configs/ubuntu16_04_clang/BUILD
+++ b/configs/ubuntu16_04_clang/BUILD
@@ -26,7 +26,7 @@ load(
 )
 
 # Created on 2018.05.09
-# Container: marketplace.gcr.io/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7
+# Container: gcr.io/cloud-marketplace/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7
 docker_toolchain_autoconfig(
     name = "ubuntu16_04-clang-1.0-bazel_0.13.0-autoconfig",
     additional_repos = ubuntu16_04_clang_default_repos(),
@@ -40,7 +40,7 @@ docker_toolchain_autoconfig(
 )
 
 # Created on 2018.05.09
-# Container: marketplace.gcr.io/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7
+# Container: gcr.io/cloud-marketplace/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7
 docker_toolchain_autoconfig(
     name = "msan-ubuntu16_04-clang-1.0-bazel_0.13.0-autoconfig",
     additional_repos = ubuntu16_04_clang_default_repos(),
@@ -56,7 +56,7 @@ docker_toolchain_autoconfig(
 )
 
 # Created on 2018.06.08
-# Container: marketplace.gcr.io/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7
+# Container: gcr.io/cloud-marketplace/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7
 docker_toolchain_autoconfig(
     name = "ubuntu16_04-clang-1.0-bazel_0.14.1-autoconfig",
     additional_repos = ubuntu16_04_clang_default_repos(),
@@ -70,7 +70,7 @@ docker_toolchain_autoconfig(
 )
 
 # Created on 2018.06.08
-# Container: marketplace.gcr.io/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7
+# Container: gcr.io/cloud-marketplace/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7
 docker_toolchain_autoconfig(
     name = "msan-ubuntu16_04-clang-1.0-bazel_0.14.1-autoconfig",
     additional_repos = ubuntu16_04_clang_default_repos(),
@@ -86,7 +86,7 @@ docker_toolchain_autoconfig(
 )
 
 # Created on 2018.06.27
-# Container: marketplace.gcr.io/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7
+# Container: gcr.io/cloud-marketplace/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7
 docker_toolchain_autoconfig(
     name = "ubuntu16_04-clang-1.0-bazel_0.15.0-autoconfig",
     additional_repos = ubuntu16_04_clang_default_repos(),
@@ -100,7 +100,7 @@ docker_toolchain_autoconfig(
 )
 
 # Created on 2018.06.27
-# Container: marketplace.gcr.io/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7
+# Container: gcr.io/cloud-marketplace/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7
 docker_toolchain_autoconfig(
     name = "msan-ubuntu16_04-clang-1.0-bazel_0.15.0-autoconfig",
     additional_repos = ubuntu16_04_clang_default_repos(),

--- a/container/build.py
+++ b/container/build.py
@@ -312,7 +312,7 @@ cd <your project with your own build targets>
 git clone https://github.com/bazelbuild/bazel-toolchains.git
 python bazel-toolchains/container/build.py [args]
 
-Note: a file path passed to the -m param must point to a file in the form descibed above
+Note: a file path passed to the -m param must point to a file in the form descibed above 
 (except TYPE_TARBALL_MAP is not required if the -b arg is not used)
 
 To build with Google Cloud Container Builder:

--- a/examples/debian8_clang/Dockerfile
+++ b/examples/debian8_clang/Dockerfile
@@ -1,4 +1,4 @@
-FROM marketplace.gcr.io/google/clang-debian8@sha256:6bf186b59972019e55acb6a46da721584ae5520218b0516542efdaa1f09caccf
+FROM gcr.io/cloud-marketplace/google/clang-debian8@sha256:6bf186b59972019e55acb6a46da721584ae5520218b0516542efdaa1f09caccf
 
 # Install Bazel deps
 RUN apt-get update && yes | apt-get install -y \

--- a/examples/debian8_clang/README.md
+++ b/examples/debian8_clang/README.md
@@ -1,3 +1,3 @@
 This folder contains a sample Dockerfile that uses as base
-marketplace.gcr.io/google/clang-debian8:latest and installs all the
+gcr.io/cloud-marketplace/google/clang-debian8:latest and installs all the
 tools necessary to run Bazel.

--- a/release/bazelrc.tpl
+++ b/release/bazelrc.tpl
@@ -104,7 +104,7 @@ build:results-local --bes_results_url="https://source.cloud.google.com/results/i
 build:docker-sandbox --host_javabase=@bazel_toolchains//configs/ubuntu16_04_clang/1.0:jdk8
 build:docker-sandbox --javabase=@bazel_toolchains//configs/ubuntu16_04_clang/1.0:jdk8
 build:docker-sandbox --crosstool_top=@bazel_toolchains//configs/ubuntu16_04_clang/1.0/bazel_${BAZEL_VERSION}/default:toolchain
-build:docker-sandbox --experimental_docker_image=marketplace.gcr.io/google/rbe-ubuntu16-04@sha256:59bf0e191a6b5cc1ab62c2224c810681d1326bad5a27b1d36c9f40113e79da7f
+build:docker-sandbox --experimental_docker_image=gcr.io/cloud-marketplace/google/rbe-ubuntu16-04@sha256:59bf0e191a6b5cc1ab62c2224c810681d1326bad5a27b1d36c9f40113e79da7f
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker
 build:docker-sandbox --strategy=Closure=docker

--- a/release/config.py
+++ b/release/config.py
@@ -23,7 +23,7 @@ class ContainerConfigs(object):
     distro: string, base distro of container used to generate configs.
     version: string, version of the configs.
     image: string, the container registry entry of the image used to
-      generated the configs, e.g. marketplace.gcr.io/google/clang-ubuntu.
+      generated the configs, e.g. gcr.io/cloud-marketplace/google/clang-ubuntu.
     package: string, the Bazel package in which we will generate the target to
       build configs.
     platform_target: string, the platform target name of the corresponding RBE
@@ -58,7 +58,7 @@ class ContainerConfigs(object):
       version: string, version of the configs.
       image: string, the container registry entry of the image used to
         generated the configs, e.g.
-        marketplace.gcr.io/google/clang-ubuntu.
+        gcr.io/cloud-marketplace/google/clang-ubuntu.
       package: string, the Bazel package in which we will generate the target to
       build configs.
       config_types: types of config to generated with this container, e.g.

--- a/release/config_release.py
+++ b/release/config_release.py
@@ -46,7 +46,7 @@ def _get_container_configs_list(bazel_version):
   debian8_clang_configs = ContainerConfigs(
       distro="debian8",
       version="0.3.0",
-      image="marketplace.gcr.io/google/clang-debian8",
+      image="gcr.io/cloud-marketplace/google/clang-debian8",
       package="configs/debian8_clang",
       config_types=CONFIG_TYPES,
       platform_target="rbe_debian8",
@@ -56,7 +56,7 @@ def _get_container_configs_list(bazel_version):
   ubuntu16_04_clang_configs = ContainerConfigs(
       distro="ubuntu16_04",
       version="1.0",
-      image="marketplace.gcr.io/google/clang-ubuntu",
+      image="gcr.io/cloud-marketplace/google/clang-ubuntu",
       package="configs/ubuntu16_04_clang",
       config_types=CONFIG_TYPES,
       platform_target="rbe_ubuntu1604",

--- a/rules/toolchain_containers.bzl
+++ b/rules/toolchain_containers.bzl
@@ -3,17 +3,17 @@ def toolchain_container_sha256s():
         ###########################################################
         # Base images                                             #
         ###########################################################
-        # marketplace.gcr.io/google/debian8:latest
+        # gcr.io/cloud-marketplace/google/debian8:latest
         "debian8": "sha256:a6df7738c401aef6bf9c113eb1eea7f3921417fd4711ea28100681f2fe483ea2",
-        # marketplace.gcr.io/google/debian9:latest
+        # gcr.io/cloud-marketplace/google/debian9:latest
         "debian9": "sha256:1d6a9a6d106bd795098f60f4abb7083626354fa6735e81743c7f8cfca11259f0",
-        # marketplace.gcr.io/google/ubuntu16_04:latest
+        # gcr.io/cloud-marketplace/google/ubuntu16_04:latest
         "ubuntu16_04": "sha256:9f9775c124417057fd58d28835b42b30f5d0410530256d857b12eae640d0a359",
 
         ###########################################################
         # Python3 images                                          #
         ###########################################################
-        # marketplace.gcr.io/google/python:latest
+        # gcr.io/cloud-marketplace/google/python:latest
         "debian8_python3": "sha256:ace668f0f01e5e562ad09c3f128488ec33fa9126313f16505a86ae77865d1696",
         # gcr.io/google-appengine/python:latest
         "ubuntu16_04_python3": "sha256:67fd35064a812fd0ba0a6e9485410f9f2710ebf7b0787a7b350ce6a20f166bfe",
@@ -21,8 +21,8 @@ def toolchain_container_sha256s():
         ###########################################################
         # Clang images                                            #
         ###########################################################
-        # marketplace.gcr.io/google/clang-debian8:r328903
+        # gcr.io/cloud-marketplace/google/clang-debian8:r328903
         "debian8_clang": "sha256:8bb65bf0a0da8be48bbac07ebe743805f3dc5259203e19517098162bd23a768f",
-        # marketplace.gcr.io/google/clang-ubuntu:r328903
+        # gcr.io/cloud-marketplace/google/clang-ubuntu:r328903
         "ubuntu16_04_clang": "sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7",
     }


### PR DESCRIPTION
Reverts bazelbuild/bazel-toolchains#136

There is more auth-related issue with marketplace.gcr.io. Will switch once they are all addressed.