### PR TITLE
Modify rbe_windows to rbe_default.

### DIFF
--- a/configs/experimental/windows/0.1.0/BUILD
+++ b/configs/experimental/windows/0.1.0/BUILD
@@ -27,7 +27,7 @@ java_runtime(
 
 # RBE Windows 1803 image that uses "default" pool.
 platform(
-    name = "rbe_windows",
+    name = "rbe_default",
     constraint_values = [
         "@bazel_tools//platforms:x86_64",
         "@bazel_tools//platforms:windows",


### PR DESCRIPTION
This is to better comply with naming convention per @bansalvinayak's request.