### PR TITLE
Always set --tls_enabled for --config=results.

### DIFF
--- a/bazelrc/bazel-0.15.0.bazelrc
+++ b/bazelrc/bazel-0.15.0.bazelrc
@@ -91,6 +91,7 @@ build:remote --auth_enabled=true
 # Results UI.
 build:results --bes_backend="buildeventservice.googleapis.com"
 build:results --bes_timeout=60s
+build:results --tls_enabled
 
 # If the upload to BES fails, the build will fail.
 build:results --bes_best_effort=false

--- a/release/bazelrc.tpl
+++ b/release/bazelrc.tpl
@@ -80,6 +80,7 @@ build:remote --auth_enabled=true
 # Results UI.
 build:results --bes_backend="buildeventservice.googleapis.com"
 build:results --bes_timeout=60s
+build:results --tls_enabled
 
 # Output BES results url
 build:results --bes_results_url="https://source.cloud.google.com/results/invocations/"


### PR DESCRIPTION
This is required for gRPC to connect to the Build Event Service as
mandated by gRPC. Without --tls_enabled, the server will respond with
the error:

    INTERNAL: First received frame was not SETTINGS. Hex dump for first
    5 bytes: 485454502f

This was verified by running this bazel commandline against the
github.com/grpc/grpc repo root:

    ~/bin/bazel-0.15.0                                          \
    --bazelrc=$HOME/src/bazel-toolchains/bazelrc/0.15.0.bazelrc \
    test                                                        \
    //test/cpp/util:slice_test@poller=epoll1                    \
    --config=results                                            \
    --auth_credentials=$HOME/src/$PROJECT_ID.credential.json    \
    --project_id=$PROJECT_ID