### PR TITLE
adding GCOV env var to clang layers

### DIFF
--- a/container/common/layers/clang/BUILD
+++ b/container/common/layers/clang/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2017 The Bazel Authors. All rights reserved.
+# Copyright 2016 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,21 +15,3 @@
 licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
-
-load(
-    "//container/rules:docker_toolchains.bzl",
-    "language_tool_layer",
-)
-
-language_tool_layer(
-    name = "clang-ltl",
-    base = "@debian8//image",
-    env = clang_env,
-    packages = [
-        "libstdc++-4.9-dev",
-    ],
-    tars = [
-        "//third_party/clang:debian8_tar",
-        "//third_party/libcxx:debian8_tar",
-    ],
-)

--- a/container/common/layers/clang/clang.bzl
+++ b/container/common/layers/clang/clang.bzl
@@ -1,0 +1,6 @@
+clang_env = {
+    "CC": "/usr/local/bin/clang",
+    "GCOV": "/dev/null",
+    "ASAN_SYMBOLIZER_PATH": "/usr/local/bin/llvm-symbolizer",
+    "MSAN_SYMBOLIZER_PATH": "/usr/local/bin/llvm-symbolizer",
+}

--- a/container/debian8/layers/clang/BUILD
+++ b/container/debian8/layers/clang/BUILD
@@ -20,6 +20,10 @@ load(
     "//container/rules:docker_toolchains.bzl",
     "language_tool_layer",
 )
+load(
+    "//container/common/layers/clang:clang.bzl",
+    "clang_env",
+)
 
 language_tool_layer(
     name = "clang-ltl",

--- a/container/experimental/rbe-debian8/BUILD
+++ b/container/experimental/rbe-debian8/BUILD
@@ -25,6 +25,10 @@ load(
     "java_layer_packages",
     "python_layer_packages",
 )
+load(
+    "//container/common/layers/clang:clang.bzl",
+    "clang_env",
+)
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load(
     "@io_bazel_rules_docker//container:container.bzl",

--- a/container/experimental/rbe-debian8/BUILD
+++ b/container/experimental/rbe-debian8/BUILD
@@ -72,11 +72,7 @@ container_layer(
 container_layer(
     name = "clang-ltl",
     debs = clang_layer_packages(),
-    env = {
-        "CC": "/usr/local/bin/clang",
-        "ASAN_SYMBOLIZER_PATH": "/usr/local/bin/llvm-symbolizer",
-        "MSAN_SYMBOLIZER_PATH": "/usr/local/bin/llvm-symbolizer",
-    },
+    env = clang_env,
     tags = ["manual"],
     tars = [
         "//third_party/clang:debian8_tar",

--- a/container/experimental/rbe-debian9/BUILD
+++ b/container/experimental/rbe-debian9/BUILD
@@ -21,6 +21,10 @@ load(
     "language_tool_layer",
     "toolchain_container",
 )
+load(
+    "//container/common/layers/clang:clang.bzl",
+    "clang_env",
+)
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
 JAVA_CLEANUP_COMMANDS = (

--- a/container/experimental/rbe-debian9/BUILD
+++ b/container/experimental/rbe-debian9/BUILD
@@ -83,11 +83,7 @@ language_tool_layer(
 language_tool_layer(
     name = "clang-ltl",
     base = "@debian9//image",
-    env = {
-        "CC": "/usr/local/bin/clang",
-        "ASAN_SYMBOLIZER_PATH": "/usr/local/bin/llvm-symbolizer",
-        "MSAN_SYMBOLIZER_PATH": "/usr/local/bin/llvm-symbolizer",
-    },
+    env = clang_env,
     packages = [
         "libstdc++-6-dev",
     ],

--- a/container/ubuntu16_04/layers/clang/BUILD
+++ b/container/ubuntu16_04/layers/clang/BUILD
@@ -20,15 +20,15 @@ load(
     "//container/rules:docker_toolchains.bzl",
     "language_tool_layer",
 )
+load(
+    "//container/common/layers/clang:clang.bzl",
+    "clang_env",
+)
 
 language_tool_layer(
     name = "clang-ltl",
     base = "@ubuntu16_04//image",
-    env = {
-        "CC": "/usr/local/bin/clang",
-        "ASAN_SYMBOLIZER_PATH": "/usr/local/bin/llvm-symbolizer",
-        "MSAN_SYMBOLIZER_PATH": "/usr/local/bin/llvm-symbolizer",
-    },
+    env = clang_env,
     packages = [
         "libstdc++-4.9-dev",
     ],


### PR DESCRIPTION
* Use of var will remove warning in bazel builds
* also refactor env vars for clang to a separate package