### PR TITLE
undo change to Remove use of external folder in package tar

### DIFF
--- a/rules/docker_config.bzl
+++ b/rules/docker_config.bzl
@@ -250,7 +250,7 @@ def _docker_toolchain_autoconfig_impl(ctx):
     remove_repo_cmd = "cd ."
     if ctx.attr.repo_pkg_tar:
         repo_pkg_tar = str(ctx.attr.repo_pkg_tar.label.name)
-        package_name = str(ctx.attr.repo_pkg_tar.label.package)
+        package_name = _EXTERNAL_FOLDER_PREFIX + _WORKSPACE_NAME + "/" + str(ctx.attr.repo_pkg_tar.label.package)
 
         # Expand the tar file pointed by repo_pkg_tar
         expand_repo_cmd = ("mkdir ./%s ; tar -xf %s/%s.tar -C ./%s" %


### PR DESCRIPTION
In https://github.com/bazelbuild/bazel-toolchains/pull/150 we removed use of the external folder in the package_name for the default cc package used for docker_toolchain_autoconfig due to failures with bazel head. This change broke use of the rule from external repos.

Will need to keep track if this CL breaks Bazel CI with head to figure out a fix that does not impact use of the rule from external repos.