### PR TITLE
Remove @bazel_toolchains in load statements in BUILDs.

### DIFF
--- a/configs/experimental/BUILD
+++ b/configs/experimental/BUILD
@@ -15,30 +15,3 @@
 licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
-
-load("@bazel_toolchains//rules:docker_config.bzl", "docker_toolchain_autoconfig")
-load(
-    "@bazel_toolchains//rules:environments.bzl",
-    "clang_env",
-    "debian8_clang_default_keys",
-    "debian8_clang_default_packages",
-    "debian8_clang_default_repos",
-)
-
-# Created on 2018.02.13
-# Container: gcr.io/cloud-marketplace/google/clang-debian8@sha256:ac3b1fdc22c0f2b95abe67f2daf33788425fab52d4e6845900bfe1a42443098f
-# This config is still experimental
-# TODO(ngiraldo): remove experimental comment once this has been tested
-docker_toolchain_autoconfig(
-    name = "msan-debian8-clang-0.3.0-bazel_0.11.0-autoconfig",
-    additional_repos = debian8_clang_default_repos(),
-    base = "@debian8-clang//image",
-    bazel_version = "0.11.0",
-    env = clang_env() + {
-        "BAZEL_LINKOPTS": "-lc++:-lc++abi:-lm",
-    },
-    keys = debian8_clang_default_keys(),
-    packages = debian8_clang_default_packages(),
-    tags = ["manual"],
-    test = True,
-)

--- a/container/common/BUILD
+++ b/container/common/BUILD
@@ -19,11 +19,11 @@ package(default_visibility = ["//visibility:public"])
 exports_files(glob(["*.yaml"]))
 
 load(
-    "@bazel_toolchains//third_party/golang:revision.bzl",
+    "//third_party/golang:revision.bzl",
     "GOLANG_REVISION",
 )
 load(
-    "@bazel_toolchains//third_party/openjdk:revision.bzl",
+    "//third_party/openjdk:revision.bzl",
     "JDK_VERSION",
     "JDK_VERSION_DECODED",
 )

--- a/container/common/bazel/BUILD
+++ b/container/common/bazel/BUILD
@@ -16,7 +16,7 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
-load("@bazel_toolchains//container/common/bazel:version.bzl", "BAZEL_VERSION_SHA256S")
+load("//container/common/bazel:version.bzl", "BAZEL_VERSION_SHA256S")
 
 exports_files(glob(["**"]))
 

--- a/container/common/clang/BUILD
+++ b/container/common/clang/BUILD
@@ -17,7 +17,7 @@ licenses(["notice"])  # Apache 2.0
 package(default_visibility = ["//visibility:public"])
 
 load(
-    "@bazel_toolchains//third_party/clang:revision.bzl",
+    "//third_party/clang:revision.bzl",
     "CLANG_REVISION",
 )
 

--- a/container/debian8/builders/bazel/BUILD
+++ b/container/debian8/builders/bazel/BUILD
@@ -17,13 +17,13 @@ licenses(["notice"])  # Apache 2.0
 package(default_visibility = ["//visibility:public"])
 
 load(
-    "@bazel_toolchains//rules/container:docker_toolchains.bzl",
+    "//rules/container:docker_toolchains.bzl",
     "language_tool_layer",
     "toolchain_container",
 )
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@bazel_toolchains//container/common/bazel:version.bzl", "BAZEL_VERSION_SHA256S")
+load("//container/common/bazel:version.bzl", "BAZEL_VERSION_SHA256S")
 
 # Tools that are needed in most builds, but not strictly required by bazel.
 language_tool_layer(

--- a/container/debian8/builders/rbe-debian8/BUILD
+++ b/container/debian8/builders/rbe-debian8/BUILD
@@ -17,7 +17,7 @@ licenses(["notice"])  # Apache 2.0
 package(default_visibility = ["//visibility:public"])
 
 load(
-    "@bazel_toolchains//rules/container:docker_toolchains.bzl",
+    "//rules/container:docker_toolchains.bzl",
     "language_tool_layer",
     "toolchain_container",
 )

--- a/container/debian8/layers/bazel/BUILD
+++ b/container/debian8/layers/bazel/BUILD
@@ -16,10 +16,10 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
-load("@bazel_toolchains//rules/container:docker_toolchains.bzl", "language_tool_layer")
-load("@bazel_toolchains//rules/container:docker_toolchains.bzl", "toolchain_container")
+load("//rules/container:docker_toolchains.bzl", "language_tool_layer")
+load("//rules/container:docker_toolchains.bzl", "toolchain_container")
 load("@base_images_docker//util:run.bzl", "container_run_and_extract")
-load("@bazel_toolchains//container/common/bazel:version.bzl", "BAZEL_VERSION_SHA256S")
+load("//container/common/bazel:version.bzl", "BAZEL_VERSION_SHA256S")
 
 # Tools required by Bazel. Note that we do not add a CC complier here as we
 # will include that in the final container.

--- a/container/debian8/layers/clang/BUILD
+++ b/container/debian8/layers/clang/BUILD
@@ -17,10 +17,10 @@ licenses(["notice"])  # Apache 2.0
 package(default_visibility = ["//visibility:public"])
 
 load(
-    "@bazel_toolchains//rules/container:docker_toolchains.bzl",
+    "//rules/container:docker_toolchains.bzl",
     "language_tool_layer",
 )
-load("@bazel_toolchains//container/common/clang:clang.bzl", "clang_env")
+load("//container/common/clang:clang.bzl", "clang_env")
 
 language_tool_layer(
     name = "clang-ltl",

--- a/container/debian8/layers/go/BUILD
+++ b/container/debian8/layers/go/BUILD
@@ -17,7 +17,7 @@ licenses(["notice"])  # Apache 2.0
 package(default_visibility = ["//visibility:public"])
 
 load(
-    "@bazel_toolchains//rules/container:docker_toolchains.bzl",
+    "//rules/container:docker_toolchains.bzl",
     "language_tool_layer",
 )
 

--- a/container/debian8/layers/java/BUILD
+++ b/container/debian8/layers/java/BUILD
@@ -17,7 +17,7 @@ licenses(["notice"])  # Apache 2.0
 package(default_visibility = ["//visibility:public"])
 
 load(
-    "@bazel_toolchains//rules/container:docker_toolchains.bzl",
+    "//rules/container:docker_toolchains.bzl",
     "language_tool_layer",
 )
 

--- a/container/debian8/layers/python/BUILD
+++ b/container/debian8/layers/python/BUILD
@@ -17,7 +17,7 @@ licenses(["notice"])  # Apache 2.0
 package(default_visibility = ["//visibility:public"])
 
 load(
-    "@bazel_toolchains//rules/container:docker_toolchains.bzl",
+    "//rules/container:docker_toolchains.bzl",
     "language_tool_layer",
 )
 

--- a/container/experimental/rbe-debian8/BUILD
+++ b/container/experimental/rbe-debian8/BUILD
@@ -19,7 +19,7 @@ package(default_visibility = ["//visibility:public"])
 load("@distroless//cacerts:cacerts.bzl", "cacerts")
 load("@jessie_package_bundle//file:packages.bzl", "packages")
 load(
-    "@bazel_toolchains//skylib:packages.bzl",
+    "//skylib:packages.bzl",
     "base_layer_packages",
     "clang_layer_packages",
     "java_layer_packages",

--- a/container/experimental/rbe-debian9/BUILD
+++ b/container/experimental/rbe-debian9/BUILD
@@ -17,12 +17,12 @@ licenses(["notice"])  # Apache 2.0
 package(default_visibility = ["//visibility:public"])
 
 load(
-    "@bazel_toolchains//rules/container:docker_toolchains.bzl",
+    "//rules/container:docker_toolchains.bzl",
     "language_tool_layer",
     "toolchain_container",
 )
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@bazel_toolchains//container/common/clang:clang.bzl", "clang_env")
+load("//container/common/clang:clang.bzl", "clang_env")
 
 JAVA_CLEANUP_COMMANDS = (
     "rm -rf " +

--- a/container/ubuntu14_04/builders/bazel/BUILD
+++ b/container/ubuntu14_04/builders/bazel/BUILD
@@ -17,13 +17,13 @@ licenses(["notice"])  # Apache 2.0
 package(default_visibility = ["//visibility:public"])
 
 load(
-    "@bazel_toolchains//rules/container:docker_toolchains.bzl",
+    "//rules/container:docker_toolchains.bzl",
     "language_tool_layer",
     "toolchain_container",
 )
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@bazel_toolchains//container/common/bazel:version.bzl", "BAZEL_VERSION_SHA256S")
+load("//container/common/bazel:version.bzl", "BAZEL_VERSION_SHA256S")
 
 # Tools that are needed in most builds, but not strictly required by bazel.
 language_tool_layer(

--- a/container/ubuntu14_04/layers/bazel/BUILD
+++ b/container/ubuntu14_04/layers/bazel/BUILD
@@ -16,10 +16,10 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
-load("@bazel_toolchains//rules/container:docker_toolchains.bzl", "language_tool_layer")
-load("@bazel_toolchains//rules/container:docker_toolchains.bzl", "toolchain_container")
+load("//rules/container:docker_toolchains.bzl", "language_tool_layer")
+load("//rules/container:docker_toolchains.bzl", "toolchain_container")
 load("@base_images_docker//util:run.bzl", "container_run_and_extract")
-load("@bazel_toolchains//container/common/bazel:version.bzl", "BAZEL_VERSION_SHA256S")
+load("//container/common/bazel:version.bzl", "BAZEL_VERSION_SHA256S")
 
 # Tools required by Bazel. Note that we do not add a CC complier here as we
 # will include that in the final container.

--- a/container/ubuntu14_04/layers/gcc/BUILD
+++ b/container/ubuntu14_04/layers/gcc/BUILD
@@ -17,7 +17,7 @@ licenses(["notice"])  # Apache 2.0
 package(default_visibility = ["//visibility:public"])
 
 load(
-    "@bazel_toolchains//rules/container:docker_toolchains.bzl",
+    "//rules/container:docker_toolchains.bzl",
     "language_tool_layer",
 )
 

--- a/container/ubuntu14_04/layers/java/BUILD
+++ b/container/ubuntu14_04/layers/java/BUILD
@@ -17,7 +17,7 @@ licenses(["notice"])  # Apache 2.0
 package(default_visibility = ["//visibility:public"])
 
 load(
-    "@bazel_toolchains//rules/container:docker_toolchains.bzl",
+    "//rules/container:docker_toolchains.bzl",
     "language_tool_layer",
 )
 

--- a/container/ubuntu14_04/layers/python/BUILD
+++ b/container/ubuntu14_04/layers/python/BUILD
@@ -17,7 +17,7 @@ licenses(["notice"])  # Apache 2.0
 package(default_visibility = ["//visibility:public"])
 
 load(
-    "@bazel_toolchains//rules/container:docker_toolchains.bzl",
+    "//rules/container:docker_toolchains.bzl",
     "language_tool_layer",
 )
 

--- a/container/ubuntu16_04/builders/bazel/BUILD
+++ b/container/ubuntu16_04/builders/bazel/BUILD
@@ -17,7 +17,7 @@ licenses(["notice"])  # Apache 2.0
 package(default_visibility = ["//visibility:public"])
 
 load(
-    "@bazel_toolchains//rules/container:docker_toolchains.bzl",
+    "//rules/container:docker_toolchains.bzl",
     "language_tool_layer",
     "toolchain_container",
 )

--- a/container/ubuntu16_04/builders/bazel_docker_gcloud/BUILD
+++ b/container/ubuntu16_04/builders/bazel_docker_gcloud/BUILD
@@ -17,7 +17,7 @@ licenses(["notice"])  # Apache 2.0
 package(default_visibility = ["//visibility:public"])
 
 load(
-    "@bazel_toolchains//rules/container:docker_toolchains.bzl",
+    "//rules/container:docker_toolchains.bzl",
     "language_tool_layer",
     "toolchain_container",
 )

--- a/container/ubuntu16_04/builders/rbe-ubuntu16_04/BUILD
+++ b/container/ubuntu16_04/builders/rbe-ubuntu16_04/BUILD
@@ -17,7 +17,7 @@ licenses(["notice"])  # Apache 2.0
 package(default_visibility = ["//visibility:public"])
 
 load(
-    "@bazel_toolchains//rules/container:docker_toolchains.bzl",
+    "//rules/container:docker_toolchains.bzl",
     "language_tool_layer",
     "toolchain_container",
 )

--- a/container/ubuntu16_04/debian_pkgs/BUILD
+++ b/container/ubuntu16_04/debian_pkgs/BUILD
@@ -17,7 +17,7 @@ licenses(["notice"])  # Apache 2.0
 package(default_visibility = ["//visibility:public"])
 
 load(
-    "@bazel_toolchains//rules/container:debian_pkg_tar.bzl",
+    "//rules/container:debian_pkg_tar.bzl",
     "aggregate_debian_pkgs",
 )
 

--- a/container/ubuntu16_04/layers/bazel/BUILD
+++ b/container/ubuntu16_04/layers/bazel/BUILD
@@ -16,9 +16,9 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
-load("@bazel_toolchains//rules/container:docker_toolchains.bzl", "language_tool_layer", "toolchain_container")
+load("//rules/container:docker_toolchains.bzl", "language_tool_layer", "toolchain_container")
 load("@base_images_docker//util:run.bzl", "container_run_and_extract")
-load("@bazel_toolchains//container/common/bazel:version.bzl", "BAZEL_VERSION_SHA256S")
+load("//container/common/bazel:version.bzl", "BAZEL_VERSION_SHA256S")
 
 # Tools required by Bazel. Note that we do not add a CC complier here as we
 # will include that in the final container.

--- a/container/ubuntu16_04/layers/clang/BUILD
+++ b/container/ubuntu16_04/layers/clang/BUILD
@@ -17,7 +17,7 @@ licenses(["notice"])  # Apache 2.0
 package(default_visibility = ["//visibility:public"])
 
 load(
-    "@bazel_toolchains//rules/container:docker_toolchains.bzl",
+    "//rules/container:docker_toolchains.bzl",
     "language_tool_layer",
 )
 load("//container/common/clang:clang.bzl", "clang_env")

--- a/container/ubuntu16_04/layers/docker-17.12.0/BUILD
+++ b/container/ubuntu16_04/layers/docker-17.12.0/BUILD
@@ -16,7 +16,7 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
-load("@bazel_toolchains//rules/container:docker_toolchains.bzl", "language_tool_layer", "toolchain_container")
+load("//rules/container:docker_toolchains.bzl", "language_tool_layer", "toolchain_container")
 load("@base_images_docker//package_managers:apt_key.bzl", "add_apt_key")
 load("@base_images_docker//package_managers:download_pkgs.bzl", "download_pkgs")
 

--- a/container/ubuntu16_04/layers/gcloud/BUILD
+++ b/container/ubuntu16_04/layers/gcloud/BUILD
@@ -16,9 +16,9 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
-load("@bazel_toolchains//rules/container:docker_toolchains.bzl", "language_tool_layer")
+load("//rules/container:docker_toolchains.bzl", "language_tool_layer")
 load(
-    "@bazel_toolchains//container/ubuntu16_04/layers/gcloud:version.bzl",
+    "//container/ubuntu16_04/layers/gcloud:version.bzl",
     "GCLOUD_VERSION",
 )
 

--- a/container/ubuntu16_04/layers/go/BUILD
+++ b/container/ubuntu16_04/layers/go/BUILD
@@ -17,7 +17,7 @@ licenses(["notice"])  # Apache 2.0
 package(default_visibility = ["//visibility:public"])
 
 load(
-    "@bazel_toolchains//rules/container:docker_toolchains.bzl",
+    "//rules/container:docker_toolchains.bzl",
     "language_tool_layer",
 )
 

--- a/container/ubuntu16_04/layers/java/BUILD
+++ b/container/ubuntu16_04/layers/java/BUILD
@@ -17,7 +17,7 @@ licenses(["notice"])  # Apache 2.0
 package(default_visibility = ["//visibility:public"])
 
 load(
-    "@bazel_toolchains//rules/container:docker_toolchains.bzl",
+    "//rules/container:docker_toolchains.bzl",
     "language_tool_layer",
 )
 

--- a/container/ubuntu16_04/layers/python/BUILD
+++ b/container/ubuntu16_04/layers/python/BUILD
@@ -17,7 +17,7 @@ licenses(["notice"])  # Apache 2.0
 package(default_visibility = ["//visibility:public"])
 
 load(
-    "@bazel_toolchains//rules/container:docker_toolchains.bzl",
+    "//rules/container:docker_toolchains.bzl",
     "language_tool_layer",
 )
 

--- a/test/configs/BUILD
+++ b/test/configs/BUILD
@@ -16,10 +16,10 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
-load("@bazel_toolchains//rules/container:docker_toolchains.bzl", "toolchain_container")
-load("@bazel_toolchains//rules:docker_config.bzl", "docker_toolchain_autoconfig")
+load("//rules/container:docker_toolchains.bzl", "toolchain_container")
+load("//rules:docker_config.bzl", "docker_toolchain_autoconfig")
 load(
-    "@bazel_toolchains//rules:environments.bzl",
+    "//rules:environments.bzl",
     "clang_env",
     "debian8_clang_default_keys",
     "debian8_clang_default_packages",

--- a/test/container/BUILD
+++ b/test/container/BUILD
@@ -19,7 +19,7 @@ package(default_visibility = ["//visibility:public"])
 load("@base_images_docker//package_managers:download_pkgs.bzl", "download_pkgs")
 load("@base_images_docker//package_managers:install_pkgs.bzl", "install_pkgs")
 load("@base_images_docker//package_managers:apt_key.bzl", "add_apt_key")
-load("@bazel_toolchains//rules/container:docker_toolchains.bzl", "toolchain_container")
+load("//rules/container:docker_toolchains.bzl", "toolchain_container")
 
 # This file contains some sample targets that excersise the container rules
 # We just keep these as examples that should not break (unless indicated)


### PR DESCRIPTION
This is not necessary and cause builds on GCB to report "ERROR: infinite symlink expansion detected".

In addition, deleted an msan docker autoconfig target under
configs/experimental/BUILD, which are now available under
non-experimental folders, i.e. configs/debian8_clang or
configs/ubuntu16_04_clang.