### PR TITLE
Move latest aliases to a different folder.

### DIFF
--- a/configs/debian8_clang/BUILD
+++ b/configs/debian8_clang/BUILD
@@ -25,41 +25,6 @@ load(
     "debian8_clang_default_repos",
 )
 
-PACKAGE = "//configs/debian8_clang/"
-
-# Update the following (if needed) in new config releases.
-LATEST_CONFIG_VERSION = "0.4.0"
-
-LATEST_BAZEL_VERSION = "0.18.0"
-
-CONFIG_TYPES = [
-    "default",
-    "msan",
-]
-
-# DO NOT depend on the following latest alias in your production jobs.
-# These are for internal and our CI use only. We DO NOT guarantee that they
-# will always work.
-[alias(
-    name = "latest_crosstool_top_" + config_type,
-    actual = PACKAGE + LATEST_CONFIG_VERSION + "/bazel_" + LATEST_BAZEL_VERSION + "/" + config_type + ":toolchain",
-) for config_type in CONFIG_TYPES]
-
-[alias(
-    name = "latest_toolchain_" + config_type,
-    actual = PACKAGE + LATEST_CONFIG_VERSION + "/bazel_" + LATEST_BAZEL_VERSION + "/cpp:cc-toolchain-clang-x86_64-" + config_type,
-) for config_type in CONFIG_TYPES]
-
-alias(
-    name = "latest_platform",
-    actual = PACKAGE + LATEST_CONFIG_VERSION + ":rbe_debian8_jdk8",
-)
-
-alias(
-    name = "latest_javabase",
-    actual = PACKAGE + LATEST_CONFIG_VERSION + ":jdk8",
-)
-
 # Created on 2017.10.18
 docker_toolchain_autoconfig(
     name = "debian8-clang-0.2.0-bazel_0.7.0-autoconfig",

--- a/configs/debian8_clang/latest/BUILD
+++ b/configs/debian8_clang/latest/BUILD
@@ -1,0 +1,52 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+licenses(["notice"])  # Apache 2.0
+
+package(default_visibility = ["//visibility:public"])
+
+PACKAGE = "//configs/debian8_clang/"
+
+# Update the following (if needed) in new config releases.
+LATEST_CONFIG_VERSION = "0.4.0"
+
+LATEST_BAZEL_VERSION = "0.18.0"
+
+CONFIG_TYPES = [
+    "default",
+    "msan",
+]
+
+# DO NOT depend on the following latest alias in your production jobs.
+# These are for internal and our CI use only. We DO NOT guarantee that they
+# will always work.
+[alias(
+    name = "crosstool_top_" + config_type,
+    actual = PACKAGE + LATEST_CONFIG_VERSION + "/bazel_" + LATEST_BAZEL_VERSION + "/" + config_type + ":toolchain",
+) for config_type in CONFIG_TYPES]
+
+[alias(
+    name = "toolchain_" + config_type,
+    actual = PACKAGE + LATEST_CONFIG_VERSION + "/bazel_" + LATEST_BAZEL_VERSION + "/cpp:cc-toolchain-clang-x86_64-" + config_type,
+) for config_type in CONFIG_TYPES]
+
+alias(
+    name = "platform",
+    actual = PACKAGE + LATEST_CONFIG_VERSION + ":rbe_debian8_jdk8",
+)
+
+alias(
+    name = "javabase",
+    actual = PACKAGE + LATEST_CONFIG_VERSION + ":jdk8",
+)

--- a/configs/ubuntu16_04_clang/BUILD
+++ b/configs/ubuntu16_04_clang/BUILD
@@ -25,41 +25,6 @@ load(
     "ubuntu16_04_clang_default_repos",
 )
 
-PACKAGE = "//configs/ubuntu16_04_clang/"
-
-# Update the following (if needed) in new config releases.
-LATEST_CONFIG_VERSION = "1.1"
-
-LATEST_BAZEL_VERSION = "0.18.0"
-
-CONFIG_TYPES = [
-    "default",
-    "msan",
-]
-
-# DO NOT depend on the following latest alias in your production jobs.
-# These are for internal and our CI use only. We DO NOT guarantee that they
-# will always work.
-[alias(
-    name = "latest_crosstool_top_" + config_type,
-    actual = PACKAGE + LATEST_CONFIG_VERSION + "/bazel_" + LATEST_BAZEL_VERSION + "/" + config_type + ":toolchain",
-) for config_type in CONFIG_TYPES]
-
-[alias(
-    name = "latest_toolchain_" + config_type,
-    actual = PACKAGE + LATEST_CONFIG_VERSION + "/bazel_" + LATEST_BAZEL_VERSION + "/cpp:cc-toolchain-clang-x86_64-" + config_type,
-) for config_type in CONFIG_TYPES]
-
-alias(
-    name = "latest_platform",
-    actual = PACKAGE + LATEST_CONFIG_VERSION + ":rbe_ubuntu1604_jdk8",
-)
-
-alias(
-    name = "latest_javabase",
-    actual = PACKAGE + LATEST_CONFIG_VERSION + ":jdk8",
-)
-
 # Created on 2018.05.09
 # Container: gcr.io/cloud-marketplace/google/clang-ubuntu@sha256:d553634f23f7c437ca35bbc4b6f1f38bb81be32b9ef2df4329dcd36762277bf7
 # Clang revision: r328903

--- a/configs/ubuntu16_04_clang/latest/BUILD
+++ b/configs/ubuntu16_04_clang/latest/BUILD
@@ -1,0 +1,52 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+licenses(["notice"])  # Apache 2.0
+
+package(default_visibility = ["//visibility:public"])
+
+PACKAGE = "//configs/ubuntu16_04_clang/"
+
+# Update the following (if needed) in new config releases.
+LATEST_CONFIG_VERSION = "1.1"
+
+LATEST_BAZEL_VERSION = "0.18.0"
+
+CONFIG_TYPES = [
+    "default",
+    "msan",
+]
+
+# DO NOT depend on the following latest alias in your production jobs.
+# These are for internal and our CI use only. We DO NOT guarantee that they
+# will always work.
+[alias(
+    name = "crosstool_top_" + config_type,
+    actual = PACKAGE + LATEST_CONFIG_VERSION + "/bazel_" + LATEST_BAZEL_VERSION + "/" + config_type + ":toolchain",
+) for config_type in CONFIG_TYPES]
+
+[alias(
+    name = "toolchain_" + config_type,
+    actual = PACKAGE + LATEST_CONFIG_VERSION + "/bazel_" + LATEST_BAZEL_VERSION + "/cpp:cc-toolchain-clang-x86_64-" + config_type,
+) for config_type in CONFIG_TYPES]
+
+alias(
+    name = "platform",
+    actual = PACKAGE + LATEST_CONFIG_VERSION + ":rbe_ubuntu1604_jdk8",
+)
+
+alias(
+    name = "javabase",
+    actual = PACKAGE + LATEST_CONFIG_VERSION + ":jdk8",
+)


### PR DESCRIPTION
The load statement for docker_toolchain_autoconfig will try to pull all
the dependencies needed to use docker_toolchain_autoconfig target, and
if the repo which depends on @bazel_toolchains does not set up all the
dependencies properly, the repo will not build.

https://github.com/bazelbuild/continuous-integration/issues/319