### PR TITLE
Add platform for new clang r342117 containers

### DIFF
--- a/configs/debian8_clang/0.4.0/BUILD
+++ b/configs/debian8_clang/0.4.0/BUILD
@@ -32,7 +32,7 @@ java_runtime(
 )
 
 # Update every time when a new container is available publically.
-LATEST_CLANG_VERSION = "r340178"
+LATEST_CLANG_VERSION = "r342117"
 
 # Latest RBE Debian8 container with JDK10
 alias(
@@ -115,6 +115,70 @@ platform(
         properties: {
           name: "container-image"
           value:"docker://gcr.io/cloud-marketplace/google/rbe-debian8@sha256:75ba06b78aa99e58cfb705378c4e3d6f0116052779d00628ecb73cd35b5ea77d"
+        }
+        """,
+)
+
+# ======================== RBE Debian8 r342117 targets ========================
+
+# RBE Debian8 r342117 with JDK 10
+platform(
+    name = "rbe_debian8_r342117_jdk10",
+    constraint_values = [
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//platforms:linux",
+        "@bazel_tools//tools/cpp:clang",
+        "//constraints/sanitizers:support_msan",
+        "//constraints:jessie",
+    ],
+    remote_execution_properties = """
+        properties: {
+          name: "container-image"
+          value:"docker://gcr.io/cloud-marketplace/google/rbe-debian8@sha256:4893599fb00089edc8351d9c26b31d3f600774cb5addefb00c70fdb6ca797abf"
+        }
+        properties: {
+          name: "jdk-version"
+          value:"10"
+        }
+        """,
+)
+
+# RBE Debian8 r342117 with JDK 8
+platform(
+    name = "rbe_debian8_r342117_jdk8",
+    constraint_values = [
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//platforms:linux",
+        "@bazel_tools//tools/cpp:clang",
+        "//constraints/sanitizers:support_msan",
+        "//constraints:jessie",
+    ],
+    remote_execution_properties = """
+        properties: {
+          name: "container-image"
+          value:"docker://gcr.io/cloud-marketplace/google/rbe-debian8@sha256:4893599fb00089edc8351d9c26b31d3f600774cb5addefb00c70fdb6ca797abf"
+        }
+        properties: {
+          name: "jdk-version"
+          value:"8"
+        }
+        """,
+)
+
+# RBE Debian8 r342117
+platform(
+    name = "rbe_debian8_r342117",
+    constraint_values = [
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//platforms:linux",
+        "@bazel_tools//tools/cpp:clang",
+        "//constraints/sanitizers:support_msan",
+        "//constraints:jessie",
+    ],
+    remote_execution_properties = """
+        properties: {
+          name: "container-image"
+          value:"docker://gcr.io/cloud-marketplace/google/rbe-debian8@sha256:4893599fb00089edc8351d9c26b31d3f600774cb5addefb00c70fdb6ca797abf"
         }
         """,
 )

--- a/configs/ubuntu16_04_clang/1.1/BUILD
+++ b/configs/ubuntu16_04_clang/1.1/BUILD
@@ -32,7 +32,7 @@ java_runtime(
 )
 
 # Update every time when a new container is available publically.
-LATEST_CLANG_VERSION = "r340178"
+LATEST_CLANG_VERSION = "r342117"
 
 # Latest RBE Ubuntu16_04 container with JDK 10
 alias(
@@ -134,6 +134,70 @@ platform(
         properties: {
           name: "container-image"
           value:"docker://gcr.io/asci-toolchain/nosla-xenial-docker@sha256:b4f34255823ae7f95f38712b85013ec26926c8c5b565b0d3f1d32e1295394e9d"
+        }
+        """,
+)
+
+# ====================== RBE Ubuntu16_04 r342117 targets ======================
+
+# RBE Ubuntu16_04 r342117 with JDK 10
+platform(
+    name = "rbe_ubuntu1604_r342117_jdk10",
+    constraint_values = [
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//platforms:linux",
+        "@bazel_tools//tools/cpp:clang",
+        "//constraints:xenial",
+        "//constraints/sanitizers:support_msan",
+    ],
+    remote_execution_properties = """
+        properties: {
+          name: "container-image"
+          value:"docker://gcr.io/cloud-marketplace/google/rbe-ubuntu16-04@sha256:f3120a030a19d67626ababdac79cc787e699a1aa924081431285118f87e7b375"
+        }
+        properties: {
+          name: "jdk-version"
+          value:"10"
+        }
+        """,
+)
+
+# RBE Ubuntu16_04 r342117 with JDK 8
+platform(
+    name = "rbe_ubuntu1604_r342117_jdk8",
+    constraint_values = [
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//platforms:linux",
+        "@bazel_tools//tools/cpp:clang",
+        "//constraints:xenial",
+        "//constraints/sanitizers:support_msan",
+    ],
+    remote_execution_properties = """
+        properties: {
+          name: "container-image"
+          value:"docker://gcr.io/cloud-marketplace/google/rbe-ubuntu16-04@sha256:f3120a030a19d67626ababdac79cc787e699a1aa924081431285118f87e7b375"
+        }
+        properties: {
+          name: "jdk-version"
+          value:"8"
+        }
+        """,
+)
+
+# RBE Ubuntu16_04 r342117
+platform(
+    name = "rbe_ubuntu1604_r342117",
+    constraint_values = [
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//platforms:linux",
+        "@bazel_tools//tools/cpp:clang",
+        "//constraints:xenial",
+        "//constraints/sanitizers:support_msan",
+    ],
+    remote_execution_properties = """
+        properties: {
+          name: "container-image"
+          value:"docker://gcr.io/cloud-marketplace/google/rbe-ubuntu16-04@sha256:f3120a030a19d67626ababdac79cc787e699a1aa924081431285118f87e7b375"
         }
         """,
 )

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -74,9 +74,9 @@ def repositories():
     if "base_images_docker" not in excludes:
         http_archive(
             name = "base_images_docker",
-            sha256 = "9540d8b1de4a0e294d5a5729c3c3f3720f4f5cdd966590e12b4dd98d5b7c10c7",
-            strip_prefix = "base-images-docker-55a4d060547899fdcd0ec662697e9212cac92996",
-            urls = ["https://github.com/GoogleCloudPlatform/base-images-docker/archive/55a4d060547899fdcd0ec662697e9212cac92996.tar.gz"],
+            sha256 = "1355ba2f4509409f3f57a4a4a03200b9431f0e37924950b02cc6955b691aee23",
+            strip_prefix = "base-images-docker-c4c3ff85458ce5dd3d93298559605d97fe948d17",
+            urls = ["https://github.com/GoogleCloudPlatform/base-images-docker/archive/c4c3ff85458ce5dd3d93298559605d97fe948d17.tar.gz"],
         )
 
     if "distroless" not in excludes:


### PR DESCRIPTION
Toolchain release for new clang containers for clang revision r342117

The containers also have an updated go version 1.11.1
Bazel default, msan and cpp configs were unchanged