### PR TITLE
Update rules_docker pin to pull in PR #559

### DIFF
--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -58,9 +58,17 @@ def repositories():
     if "io_bazel_rules_docker" not in excludes:
         http_archive(
             name = "io_bazel_rules_docker",
-            sha256 = "d9ee70d2f763ce197e2691f12d69ee8e32b2245a48d53b4365fa239b66405c0c",
-            strip_prefix = "rules_docker-7391b39ccad788524262e106d54adfdbfc3e44d5",
-            urls = ["https://github.com/bazelbuild/rules_docker/archive/7391b39ccad788524262e106d54adfdbfc3e44d5.tar.gz"],
+            sha256 = "f3e5c0500533d58be079db1a24ac909f2e0cd98c9d760f5e506e4d05b56c42dd",
+            strip_prefix = "rules_docker-a9bb1dab84cdf46e34d1b34b53a17bda129b5eba",
+            urls = ["https://github.com/bazelbuild/rules_docker/archive/a9bb1dab84cdf46e34d1b34b53a17bda129b5eba.tar.gz"],
+        )
+        # Register the docker toolchain type
+        native.register_toolchains(
+            # Register the default docker toolchain that expects the 'docker'
+            # executable to be in the PATH
+            "@io_bazel_rules_docker//toolchains/docker:default_linux_toolchain",
+            "@io_bazel_rules_docker//toolchains/docker:default_windows_toolchain",
+            "@io_bazel_rules_docker//toolchains/docker:default_osx_toolchain",
         )
 
     # io_bazel_rules_go is the dependency of container_test rules.

--- a/rules/container/docker_toolchains.bzl
+++ b/rules/container/docker_toolchains.bzl
@@ -196,6 +196,7 @@ language_tool_layer_ = rule(
     attrs = language_tool_layer_attrs,
     executable = True,
     outputs = _container.image.outputs,
+    toolchains = ["@io_bazel_rules_docker//toolchains/docker:toolchain_type"],
     implementation = _language_tool_layer_impl,
 )
 
@@ -302,6 +303,7 @@ toolchain_container_ = rule(
     },
     executable = True,
     outputs = _container.image.outputs,
+    toolchains = ["@io_bazel_rules_docker//toolchains/docker:toolchain_type"],
     implementation = _toolchain_container_impl,
 )
 

--- a/rules/docker_config.bzl
+++ b/rules/docker_config.bzl
@@ -325,6 +325,7 @@ docker_toolchain_autoconfig_ = rule(
         "log": "%{name}.log",
         "output_tar": "%{name}_outputs.tar",
     },
+    toolchains = ["@io_bazel_rules_docker//toolchains/docker:toolchain_type"],
     implementation = _docker_toolchain_autoconfig_impl,
 )
 


### PR DESCRIPTION
Pulls in the version that uses toolchain rules in the container
image rule for the docker toolchain