### PR TITLE
Remove referring to repo itself when using own rules.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -78,7 +78,7 @@ http_file(
 )
 
 # Download test file to test gcs_file rule
-load("@bazel_toolchains//rules:gcs.bzl", "gcs_file")
+load("//rules:gcs.bzl", "gcs_file")
 
 gcs_file(
     name = "download_test_gcs_file",


### PR DESCRIPTION
This is to avoid creating infinite symlink expansion in the GCB job to
create containers.

The reason why this is happening is because in the our GCB job, we
intentially set the bazel output_base to be the /workspace directory in
order for some file mounting needed by the base-images-docker to work properly.
/workspace is also where the source code of the repo is located on the
GCB. The side effect of that is if we use bazel_toolchains as another
external dependency (by adding @bazel_toolchains prefix in BUILD or
WORKSPACE when loading bazel_toolchains repo's own rules), then an
infinitie symlink expansion would occur:

[start of symlink chain]
/workspace/external/bazel_toolchains
/workspace
[end of symlink chain]

We currently haven't found a way on GCB to avoid setting the output_base
to be /workspace, and still keep the file mounting working. And putting
the source code into /workspace is done by GCB and cannot be changed.