### PR TITLE
remove experimental_strict_action_env from tpl

### DIFF
--- a/release/bazelrc.tpl
+++ b/release/bazelrc.tpl
@@ -60,11 +60,6 @@ build:remote --remote_executor=remotebuildexecution.googleapis.com
 # Enable encryption.
 build:remote --tls_enabled=true
 
-# Enforce stricter environment rules, which eliminates some non-hermetic
-# behavior and therefore improves both the remote cache hit rate and the
-# correctness and repeatability of the build.
-build:remote --experimental_strict_action_env=true
-
 # Set a higher timeout value, just in case.
 build:remote --remote_timeout=3600
 
@@ -110,7 +105,6 @@ build:docker-sandbox --experimental_enable_docker_sandbox
 # across machines, developers, and workspaces.
 build:remote-cache --remote_cache=remotebuildexecution.googleapis.com
 build:remote-cache --tls_enabled=true
-build:remote-cache --experimental_strict_action_env=true
 build:remote-cache --remote_timeout=3600
 build:remote-cache --auth_enabled=true
 build:remote-cache --spawn_strategy=standalone


### PR DESCRIPTION
experimental_strict_action_env is now set to true by default, so this is no longer needed in our upcoming bazelrcs. Not modifying current ones as I'm not sure if this was cut with 0.19.0 or 0.20.0 and its a noop if it was indeed already cut.