### PR TITLE
Provide sample WORKSPACE and bazelrc files to use with rbe_autoconf

### DIFF
--- a/examples/remotebuildexecution/rbe_system_check/.bazelrc.sample
+++ b/examples/remotebuildexecution/rbe_system_check/.bazelrc.sample
@@ -1,0 +1,42 @@
+# Copyright 2016 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A sample bazelrc flag with a minimal set of flags for Remote
+# Build Execution
+
+# Strategy flags
+build:remote --spawn_strategy=remote
+build:remote --strategy=Javac=remote
+build:remote --strategy=Closure=remote
+build:remote --genrule_strategy=remote
+build:remote --define=EXECUTOR=remote
+
+# Enable the remote API flags
+build:remote --remote_cache=remotebuildexecution.googleapis.com
+build:remote --remote_executor=remotebuildexecution.googleapis.com
+build:remote --tls_enabled=true
+build:remote --auth_enabled=true
+
+# Toolchain/platform flags that work with rbe_autoconfig rule.
+# Note target name must be set to "rbe_default" to use these flags as is.
+build:remote --crosstool_top=@rbe_default//rbe_config_cc:toolchain
+build:remote --host_javabase=@rbe_default//platforms:jdk8
+build:remote --javabase=@rbe_default//platforms:jdk8
+build:remote --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:remote --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:remote --extra_execution_platforms=@rbe_default//platforms:rbe_ubuntu1604
+build:remote --host_platform=@rbe_default//platforms:rbe_ubuntu1604
+build:remote --platforms=@rbe_default//platforms:rbe_ubuntu1604
+build:remote --extra_toolchains=@rbe_default//platforms:cc-toolchain
+

--- a/examples/remotebuildexecution/rbe_system_check/WORKSPACE.sample
+++ b/examples/remotebuildexecution/rbe_system_check/WORKSPACE.sample
@@ -1,0 +1,39 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A template file for a minimal WORKSPACE file that uses rbe_autoconfig
+# Note values for sha256 and commit are not set and should be set with
+# values in https://releases.bazel.build/bazel-toolchains.html
+
+workspace(name = "rbe_system_check")
+
+http_archive(
+    name = "bazel_toolchains",
+    sha256 = "%{sha256}",
+    strip_prefix = "bazel-toolchains-%{commit}",
+    urls = [
+        "https://github.com/bazelbuild/bazel-toolchains/archive/%{commit}.tar.gz",
+    ],
+)
+
+load(
+    "@bazel_toolchains//repositories:repositories.bzl",
+    bazel_toolchains_repositories = "repositories",
+)
+
+bazel_toolchains_repositories()
+
+load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
+
+rbe_autoconfig(name = "rbe_default")

--- a/examples/remotebuildexecution/rbe_system_check/WORKSPACE.sample
+++ b/examples/remotebuildexecution/rbe_system_check/WORKSPACE.sample
@@ -22,10 +22,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 
 http_archive(
     name = "bazel_toolchains",
-    sha256 = "%{sha256}",
-    strip_prefix = "bazel-toolchains-%{commit}",
+    sha256 = "${bazel_toolchains_sha256}",
+    strip_prefix = "bazel-toolchains-${bazel_toolchains_commit}",
     urls = [
-        "https://github.com/bazelbuild/bazel-toolchains/archive/%{commit}.tar.gz",
+        "https://github.com/bazelbuild/bazel-toolchains/archive/${bazel_toolchains_commit}.tar.gz",
     ],
 )
 

--- a/examples/remotebuildexecution/rbe_system_check/WORKSPACE.sample
+++ b/examples/remotebuildexecution/rbe_system_check/WORKSPACE.sample
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 
 http_archive(
     name = "bazel_toolchains",
-    sha256 = "<bazel_toolchains_sha25>",
+    sha256 = "<bazel_toolchains_sha256>",
     strip_prefix = "bazel-toolchains-<bazel_toolchains_commit>",
     urls = [
         "https://github.com/bazelbuild/bazel-toolchains/archive/<bazel_toolchains_commit>.tar.gz",

--- a/examples/remotebuildexecution/rbe_system_check/WORKSPACE.sample
+++ b/examples/remotebuildexecution/rbe_system_check/WORKSPACE.sample
@@ -18,6 +18,8 @@
 
 workspace(name = "rbe_system_check")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
+
 http_archive(
     name = "bazel_toolchains",
     sha256 = "%{sha256}",

--- a/examples/remotebuildexecution/rbe_system_check/WORKSPACE.sample
+++ b/examples/remotebuildexecution/rbe_system_check/WORKSPACE.sample
@@ -22,10 +22,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 
 http_archive(
     name = "bazel_toolchains",
-    sha256 = "${bazel_toolchains_sha256}",
-    strip_prefix = "bazel-toolchains-${bazel_toolchains_commit}",
+    sha256 = "<bazel_toolchains_sha25>",
+    strip_prefix = "bazel-toolchains-<bazel_toolchains_commit>",
     urls = [
-        "https://github.com/bazelbuild/bazel-toolchains/archive/${bazel_toolchains_commit}.tar.gz",
+        "https://github.com/bazelbuild/bazel-toolchains/archive/<bazel_toolchains_commit>.tar.gz",
     ],
 )
 


### PR DESCRIPTION
Adding sample files to remotebuildexecution/rbe_system_check.
All the user will need to do now is replace template values in WORKSPACE file and add their stack specific flags.