### PR TITLE
Add hello world example, including a proper test.

### DIFF
--- a/examples/remotebuildexecution/hello_world/cc/BUILD
+++ b/examples/remotebuildexecution/hello_world/cc/BUILD
@@ -1,0 +1,33 @@
+# Copyright 2016 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "say_hello",
+    srcs = ["say_hello.cc"],
+    hdrs = ["say_hello.h"],
+)
+
+cc_binary(
+    name = "hello_world",
+    srcs = ["hello_world.cc"],
+    deps = [":say_hello"],
+)
+
+cc_test(
+    name = "say_hello_test",
+    srcs = ["say_hello_test.cc"],
+    deps = [":say_hello"],
+)

--- a/examples/remotebuildexecution/hello_world/cc/hello_world.cc
+++ b/examples/remotebuildexecution/hello_world/cc/hello_world.cc
@@ -1,0 +1,22 @@
+// Copyright 2016 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "say_hello.h"
+
+#include <iostream>
+
+int main(int argc, char** argv) {
+  std::cout << sayHello("world") << std::endl;
+  return 0;
+}

--- a/examples/remotebuildexecution/hello_world/cc/say_hello.cc
+++ b/examples/remotebuildexecution/hello_world/cc/say_hello.cc
@@ -1,0 +1,19 @@
+// Copyright 2016 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+
+std::string sayHello(std::string name) {
+  return "Hello, " + name;
+}

--- a/examples/remotebuildexecution/hello_world/cc/say_hello.h
+++ b/examples/remotebuildexecution/hello_world/cc/say_hello.h
@@ -1,0 +1,17 @@
+// Copyright 2016 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+
+std::string sayHello(std::string name);

--- a/examples/remotebuildexecution/hello_world/cc/say_hello_test.cc
+++ b/examples/remotebuildexecution/hello_world/cc/say_hello_test.cc
@@ -1,0 +1,28 @@
+// Copyright 2016 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "say_hello.h"
+
+#include <iostream>
+#include <string>
+
+int main(int argc, char** argv) {
+  std::string res = sayHello("user");
+  std::string expect = "Hello, user";
+  if (res != expect) {
+    std::cout << "Want '" << expect << "', got '" << res << "'" << std::endl;
+    return 1;
+  }
+  return 0;
+}


### PR DESCRIPTION
The quickstart guide that we're working on really should use a "hello world" example rather than "rbe_system_check". Also, we want a proper lib/test division so it's possible for new users to change the test file and see that the lib isn't rebuilt.