### PR TITLE
Remove references to the Results UI from recent sample bazelrc files.

### DIFF
--- a/bazelrc/bazel-0.13.0.bazelrc
+++ b/bazelrc/bazel-0.13.0.bazelrc
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This .bazelrc file contains all of the flags required for the toolchain,
-# Remote Build Execution, and the Bazel Build Results UI. Specific flags in
-# your Bazel command allow you to use only the remote build, to use only the
-# results UI, or to use them both together.
+# This .bazelrc file contains all of the flags required for the provided
+# toolchain with Remote Build Execution.
 
 # Remote Build Execution requires a strong hash function, such as SHA256.
 startup --host_jvm_args=-Dbazel.DigestFunction=SHA256
@@ -66,22 +64,3 @@ build:remote --remote_timeout=3600
 # default. You can use --auth_credentials=some_file.json to use a service
 # account credential instead.
 build:remote --auth_enabled=true
-
-# Set flags for uploading to BES in order to view results in the Bazel Build
-# Results UI.
-build:results --bes_backend="buildeventservice.googleapis.com"
-build:results --bes_timeout=10s
-
-# If the upload to BES fails, the build will fail.
-build:results --bes_best_effort=false
-
-# Set flags for uploading to BES without Remote Build Execution.
-build:results-local --bes_backend="buildeventservice.googleapis.com"
-build:results-local --bes_timeout=10s
-build:results-local --bes_best_effort=false
-build:results-local --tls_enabled=true
-build:results-local --auth_enabled=true
-build:results-local --spawn_strategy=local
-build:results-local --experimental_remote_spawn_cache
-build:results-local --remote_cache=remotebuildexecution.googleapis.com
-build:results-local --remote_timeout=3600

--- a/bazelrc/bazel-0.14.1.bazelrc
+++ b/bazelrc/bazel-0.14.1.bazelrc
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This .bazelrc file contains all of the flags required for the toolchain,
-# Remote Build Execution, and the Bazel Build Results UI. Specific flags in
-# your Bazel command allow you to use only the remote build, to use only the
-# results UI, or to use them both together.
+# This .bazelrc file contains all of the flags required for the provided
+# toolchain with Remote Build Execution.
 
 # Remote Build Execution requires a strong hash function, such as SHA256.
 startup --host_jvm_args=-Dbazel.DigestFunction=SHA256
@@ -71,29 +69,6 @@ build:remote --remote_timeout=3600
 # default. You can use --auth_credentials=some_file.json to use a service
 # account credential instead.
 build:remote --auth_enabled=true
-
-# Set flags for uploading to BES in order to view results in the Bazel Build
-# Results UI.
-build:results --bes_backend="buildeventservice.googleapis.com"
-build:results --bes_timeout=60s
-
-# If the upload to BES fails, the build will fail.
-build:results --bes_best_effort=false
-
-# Output BES results url
-build:results --bes_results_url="https://source.cloud.google.com/results/invocations/"
-
-# Set flags for uploading to BES without Remote Build Execution.
-build:results-local --bes_backend="buildeventservice.googleapis.com"
-build:results-local --bes_timeout=60s
-build:results-local --bes_best_effort=false
-build:results-local --tls_enabled=true
-build:results-local --auth_enabled=true
-build:results-local --spawn_strategy=local
-build:results-local --experimental_remote_spawn_cache
-build:results-local --remote_cache=remotebuildexecution.googleapis.com
-build:results-local --remote_timeout=3600
-build:results-local --bes_results_url="https://source.cloud.google.com/results/invocations/"
 
 # The following flags are only necessary for local docker sandboxing
 # with the rbe-ubuntu16-04 container. Use of these flags is still experimental.

--- a/bazelrc/bazel-0.15.0.bazelrc
+++ b/bazelrc/bazel-0.15.0.bazelrc
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This .bazelrc file contains all of the flags required for the toolchain,
-# Remote Build Execution, and the Bazel Build Results UI. Specific flags in
-# your Bazel command allow you to use only the remote build, to use only the
-# results UI, or to use them both together.
+# This .bazelrc file contains all of the flags required for the provided
+# toolchain with Remote Build Execution.
 #
 # This .bazelrc file also contains all of the flags required for the local
 # docker sandboxing.
@@ -86,30 +84,6 @@ build:remote --remote_timeout=3600
 # default. You can use --auth_credentials=some_file.json to use a service
 # account credential instead.
 build:remote --auth_enabled=true
-
-# Set flags for uploading to BES in order to view results in the Bazel Build
-# Results UI.
-build:results --bes_backend="buildeventservice.googleapis.com"
-build:results --bes_timeout=60s
-build:results --tls_enabled
-
-# If the upload to BES fails, the build will fail.
-build:results --bes_best_effort=false
-
-# Output BES results url
-build:results --bes_results_url="https://source.cloud.google.com/results/invocations/"
-
-# Set flags for uploading to BES without Remote Build Execution.
-build:results-local --bes_backend="buildeventservice.googleapis.com"
-build:results-local --bes_timeout=60s
-build:results-local --bes_best_effort=false
-build:results-local --tls_enabled=true
-build:results-local --auth_enabled=true
-build:results-local --spawn_strategy=local
-build:results-local --experimental_remote_spawn_cache
-build:results-local --remote_cache=remotebuildexecution.googleapis.com
-build:results-local --remote_timeout=3600
-build:results-local --bes_results_url="https://source.cloud.google.com/results/invocations/"
 
 # The following flags are only necessary for local docker sandboxing
 # with the rbe-ubuntu16-04 container. Use of these flags is still experimental.

--- a/bazelrc/bazel-0.16.1.bazelrc
+++ b/bazelrc/bazel-0.16.1.bazelrc
@@ -15,10 +15,8 @@
 # This file is auto-generated from release/bazelrc.tpl and should not be
 # modified directly.
 
-# This .bazelrc file contains all of the flags required for the toolchain,
-# Remote Build Execution, and the Bazel Build Results UI. Specific flags in
-# your Bazel command allow you to use only the remote build, to use only the
-# results UI, or to use them both together.
+# This .bazelrc file contains all of the flags required for the provided
+# toolchain with Remote Build Execution.
 #
 # This .bazelrc file also contains all of the flags required for the local
 # docker sandboxing.
@@ -89,25 +87,6 @@ build:remote --remote_timeout=3600
 # default. You can use --auth_credentials=some_file.json to use a service
 # account credential instead.
 build:remote --auth_enabled=true
-
-# Set flags for uploading to BES in order to view results in the Bazel Build
-# Results UI.
-build:results --bes_backend="buildeventservice.googleapis.com"
-build:results --bes_timeout=60s
-build:results --tls_enabled
-
-# Output BES results url
-build:results --bes_results_url="https://source.cloud.google.com/results/invocations/"
-
-# Set flags for uploading to BES without Remote Build Execution.
-build:results-local --bes_backend="buildeventservice.googleapis.com"
-build:results-local --bes_timeout=60s
-build:results-local --tls_enabled=true
-build:results-local --auth_enabled=true
-build:results-local --spawn_strategy=local
-build:results-local --remote_cache=remotebuildexecution.googleapis.com
-build:results-local --remote_timeout=3600
-build:results-local --bes_results_url="https://source.cloud.google.com/results/invocations/"
 
 # The following flags are only necessary for local docker sandboxing
 # with the rbe-ubuntu16-04 container. Use of these flags is still experimental.

--- a/bazelrc/bazel-0.17.1.bazelrc
+++ b/bazelrc/bazel-0.17.1.bazelrc
@@ -15,10 +15,8 @@
 # This file is auto-generated from release/bazelrc.tpl and should not be
 # modified directly.
 
-# This .bazelrc file contains all of the flags required for the toolchain,
-# Remote Build Execution, and the Bazel Build Results UI. Specific flags in
-# your Bazel command allow you to use only the remote build, to use only the
-# results UI, or to use them both together.
+# This .bazelrc file contains all of the flags required for the provided
+# toolchain with Remote Build Execution.
 #
 # This .bazelrc file also contains all of the flags required for the local
 # docker sandboxing.
@@ -86,25 +84,6 @@ build:remote --remote_timeout=3600
 # default. You can use --auth_credentials=some_file.json to use a service
 # account credential instead.
 build:remote --auth_enabled=true
-
-# Set flags for uploading to BES in order to view results in the Bazel Build
-# Results UI.
-build:results --bes_backend="buildeventservice.googleapis.com"
-build:results --bes_timeout=60s
-build:results --tls_enabled
-
-# Output BES results url
-build:results --bes_results_url="https://source.cloud.google.com/results/invocations/"
-
-# Set flags for uploading to BES without Remote Build Execution.
-build:results-local --bes_backend="buildeventservice.googleapis.com"
-build:results-local --bes_timeout=60s
-build:results-local --tls_enabled=true
-build:results-local --auth_enabled=true
-build:results-local --spawn_strategy=local
-build:results-local --remote_cache=remotebuildexecution.googleapis.com
-build:results-local --remote_timeout=3600
-build:results-local --bes_results_url="https://source.cloud.google.com/results/invocations/"
 
 # The following flags are only necessary for local docker sandboxing
 # with the rbe-ubuntu16-04 container. Use of these flags is still experimental.

--- a/bazelrc/bazel-0.18.0.bazelrc
+++ b/bazelrc/bazel-0.18.0.bazelrc
@@ -15,10 +15,8 @@
 # This file is auto-generated from release/bazelrc.tpl and should not be
 # modified directly.
 
-# This .bazelrc file contains all of the flags required for the toolchain,
-# Remote Build Execution, and the Bazel Build Results UI. Specific flags in
-# your Bazel command allow you to use only the remote build, to use only the
-# results UI, or to use them both together.
+# This .bazelrc file contains all of the flags required for the provided
+# toolchain with Remote Build Execution.
 #
 # This .bazelrc file also contains all of the flags required for the local
 # docker sandboxing.
@@ -86,25 +84,6 @@ build:remote --remote_timeout=3600
 # default. You can use --auth_credentials=some_file.json to use a service
 # account credential instead.
 build:remote --auth_enabled=true
-
-# Set flags for uploading to BES in order to view results in the Bazel Build
-# Results UI.
-build:results --bes_backend="buildeventservice.googleapis.com"
-build:results --bes_timeout=60s
-build:results --tls_enabled
-
-# Output BES results url
-build:results --bes_results_url="https://source.cloud.google.com/results/invocations/"
-
-# Set flags for uploading to BES without Remote Build Execution.
-build:results-local --bes_backend="buildeventservice.googleapis.com"
-build:results-local --bes_timeout=60s
-build:results-local --tls_enabled=true
-build:results-local --auth_enabled=true
-build:results-local --spawn_strategy=local
-build:results-local --remote_cache=remotebuildexecution.googleapis.com
-build:results-local --remote_timeout=3600
-build:results-local --bes_results_url="https://source.cloud.google.com/results/invocations/"
 
 # The following flags are only necessary for local docker sandboxing
 # with the rbe-ubuntu16-04 container. Use of these flags is still experimental.

--- a/bazelrc/bazel-0.19.0.bazelrc
+++ b/bazelrc/bazel-0.19.0.bazelrc
@@ -15,10 +15,8 @@
 # This file is auto-generated from release/bazelrc.tpl and should not be
 # modified directly.
 
-# This .bazelrc file contains all of the flags required for the toolchain,
-# Remote Build Execution, and the Bazel Build Results UI. Specific flags in
-# your Bazel command allow you to use only the remote build, to use only the
-# results UI, or to use them both together.
+# This .bazelrc file contains all of the flags required for the provided
+# toolchain with Remote Build Execution.
 #
 # This .bazelrc file also contains all of the flags required for the local
 # docker sandboxing.
@@ -86,25 +84,6 @@ build:remote --remote_timeout=3600
 # default. You can use --auth_credentials=some_file.json to use a service
 # account credential instead.
 build:remote --auth_enabled=true
-
-# Set flags for uploading to BES in order to view results in the Bazel Build
-# Results UI.
-build:results --bes_backend="buildeventservice.googleapis.com"
-build:results --bes_timeout=60s
-build:results --tls_enabled
-
-# Output BES results url
-build:results --bes_results_url="https://source.cloud.google.com/results/invocations/"
-
-# Set flags for uploading to BES without Remote Build Execution.
-build:results-local --bes_backend="buildeventservice.googleapis.com"
-build:results-local --bes_timeout=60s
-build:results-local --tls_enabled=true
-build:results-local --auth_enabled=true
-build:results-local --spawn_strategy=local
-build:results-local --remote_cache=remotebuildexecution.googleapis.com
-build:results-local --remote_timeout=3600
-build:results-local --bes_results_url="https://source.cloud.google.com/results/invocations/"
 
 # The following flags are only necessary for local docker sandboxing
 # with the rbe-ubuntu16-04 container. Use of these flags is still experimental.

--- a/bazelrc/bazel-0.19.2.bazelrc
+++ b/bazelrc/bazel-0.19.2.bazelrc
@@ -15,10 +15,8 @@
 # This file is auto-generated from release/bazelrc.tpl and should not be
 # modified directly.
 
-# This .bazelrc file contains all of the flags required for the toolchain,
-# Remote Build Execution, and the Bazel Build Results UI. Specific flags in
-# your Bazel command allow you to use only the remote build, to use only the
-# results UI, or to use them both together.
+# This .bazelrc file contains all of the flags required for the provided
+# toolchain with Remote Build Execution.
 #
 # This .bazelrc file also contains all of the flags required for the local
 # docker sandboxing.
@@ -86,25 +84,6 @@ build:remote --remote_timeout=3600
 # default. You can use --auth_credentials=some_file.json to use a service
 # account credential instead.
 build:remote --auth_enabled=true
-
-# Set flags for uploading to BES in order to view results in the Bazel Build
-# Results UI.
-build:results --bes_backend="buildeventservice.googleapis.com"
-build:results --bes_timeout=60s
-build:results --tls_enabled
-
-# Output BES results url
-build:results --bes_results_url="https://source.cloud.google.com/results/invocations/"
-
-# Set flags for uploading to BES without Remote Build Execution.
-build:results-local --bes_backend="buildeventservice.googleapis.com"
-build:results-local --bes_timeout=60s
-build:results-local --tls_enabled=true
-build:results-local --auth_enabled=true
-build:results-local --spawn_strategy=local
-build:results-local --remote_cache=remotebuildexecution.googleapis.com
-build:results-local --remote_timeout=3600
-build:results-local --bes_results_url="https://source.cloud.google.com/results/invocations/"
 
 # The following flags are only necessary for local docker sandboxing
 # with the rbe-ubuntu16-04 container. Use of these flags is still experimental.

--- a/bazelrc/bazel-0.20.0.bazelrc
+++ b/bazelrc/bazel-0.20.0.bazelrc
@@ -15,10 +15,8 @@
 # This file is auto-generated from release/bazelrc.tpl and should not be
 # modified directly.
 
-# This .bazelrc file contains all of the flags required for the toolchain,
-# Remote Build Execution, and the Bazel Build Results UI. Specific flags in
-# your Bazel command allow you to use only the remote build, to use only the
-# results UI, or to use them both together.
+# This .bazelrc file contains all of the flags required for the provided
+# toolchain with Remote Build Execution.
 #
 # This .bazelrc file also contains all of the flags required for the local
 # docker sandboxing.
@@ -86,25 +84,6 @@ build:remote --remote_timeout=3600
 # default. You can use --auth_credentials=some_file.json to use a service
 # account credential instead.
 build:remote --auth_enabled=true
-
-# Set flags for uploading to BES in order to view results in the Bazel Build
-# Results UI.
-build:results --bes_backend="buildeventservice.googleapis.com"
-build:results --bes_timeout=60s
-build:results --tls_enabled
-
-# Output BES results url
-build:results --bes_results_url="https://source.cloud.google.com/results/invocations/"
-
-# Set flags for uploading to BES without Remote Build Execution.
-build:results-local --bes_backend="buildeventservice.googleapis.com"
-build:results-local --bes_timeout=60s
-build:results-local --tls_enabled=true
-build:results-local --auth_enabled=true
-build:results-local --spawn_strategy=local
-build:results-local --remote_cache=remotebuildexecution.googleapis.com
-build:results-local --remote_timeout=3600
-build:results-local --bes_results_url="https://source.cloud.google.com/results/invocations/"
 
 # The following flags are only necessary for local docker sandboxing
 # with the rbe-ubuntu16-04 container. Use of these flags is still experimental.

--- a/bazelrc/bazel-0.21.0.bazelrc
+++ b/bazelrc/bazel-0.21.0.bazelrc
@@ -15,10 +15,8 @@
 # This file is auto-generated from release/bazelrc.tpl and should not be
 # modified directly.
 
-# This .bazelrc file contains all of the flags required for the toolchain,
-# Remote Build Execution, and the Bazel Build Results UI. Specific flags in
-# your Bazel command allow you to use only the remote build, to use only the
-# results UI, or to use them both together.
+# This .bazelrc file contains all of the flags required for the provided
+# toolchain with Remote Build Execution.
 #
 # This .bazelrc file also contains all of the flags required for the local
 # docker sandboxing.
@@ -81,25 +79,6 @@ build:remote --remote_timeout=3600
 # default. You can use --auth_credentials=some_file.json to use a service
 # account credential instead.
 build:remote --auth_enabled=true
-
-# Set flags for uploading to BES in order to view results in the Bazel Build
-# Results UI.
-build:results --bes_backend="buildeventservice.googleapis.com"
-build:results --bes_timeout=60s
-build:results --tls_enabled
-
-# Output BES results url
-build:results --bes_results_url="https://source.cloud.google.com/results/invocations/"
-
-# Set flags for uploading to BES without Remote Build Execution.
-build:results-local --bes_backend="buildeventservice.googleapis.com"
-build:results-local --bes_timeout=60s
-build:results-local --tls_enabled=true
-build:results-local --auth_enabled=true
-build:results-local --spawn_strategy=local
-build:results-local --remote_cache=remotebuildexecution.googleapis.com
-build:results-local --remote_timeout=3600
-build:results-local --bes_results_url="https://source.cloud.google.com/results/invocations/"
 
 # The following flags are only necessary for local docker sandboxing
 # with the rbe-ubuntu16-04 container. Use of these flags is still experimental.

--- a/bazelrc/bazel-0.22.0.bazelrc
+++ b/bazelrc/bazel-0.22.0.bazelrc
@@ -15,10 +15,8 @@
 # This file is auto-generated from release/bazelrc.tpl and should not be
 # modified directly.
 
-# This .bazelrc file contains all of the flags required for the toolchain,
-# Remote Build Execution, and the Bazel Build Results UI. Specific flags in
-# your Bazel command allow you to use only the remote build, to use only the
-# results UI, or to use them both together.
+# This .bazelrc file contains all of the flags required for the provided
+# toolchain with Remote Build Execution.
 #
 # This .bazelrc file also contains all of the flags required for the local
 # docker sandboxing.
@@ -81,25 +79,6 @@ build:remote --remote_timeout=3600
 # default. You can use --auth_credentials=some_file.json to use a service
 # account credential instead.
 build:remote --auth_enabled=true
-
-# Set flags for uploading to BES in order to view results in the Bazel Build
-# Results UI.
-build:results --bes_backend="buildeventservice.googleapis.com"
-build:results --bes_timeout=60s
-build:results --tls_enabled
-
-# Output BES results url
-build:results --bes_results_url="https://source.cloud.google.com/results/invocations/"
-
-# Set flags for uploading to BES without Remote Build Execution.
-build:results-local --bes_backend="buildeventservice.googleapis.com"
-build:results-local --bes_timeout=60s
-build:results-local --tls_enabled=true
-build:results-local --auth_enabled=true
-build:results-local --spawn_strategy=local
-build:results-local --remote_cache=remotebuildexecution.googleapis.com
-build:results-local --remote_timeout=3600
-build:results-local --bes_results_url="https://source.cloud.google.com/results/invocations/"
 
 # The following flags are only necessary for local docker sandboxing
 # with the rbe-ubuntu16-04 container. Use of these flags is still experimental.

--- a/release/bazelrc.tpl
+++ b/release/bazelrc.tpl
@@ -1,10 +1,8 @@
 # This file is auto-generated from release/bazelrc.tpl and should not be
 # modified directly.
 
-# This .bazelrc file contains all of the flags required for the toolchain,
-# Remote Build Execution, and the Bazel Build Results UI. Specific flags in
-# your Bazel command allow you to use only the remote build, to use only the
-# results UI, or to use them both together.
+# This .bazelrc file contains all of the flags required for the provided
+# toolchain with Remote Build Execution.
 #
 # This .bazelrc file also contains all of the flags required for the local
 # docker sandboxing.
@@ -67,25 +65,6 @@ build:remote --remote_timeout=3600
 # default. You can use --auth_credentials=some_file.json to use a service
 # account credential instead.
 build:remote --auth_enabled=true
-
-# Set flags for uploading to BES in order to view results in the Bazel Build
-# Results UI.
-build:results --bes_backend="buildeventservice.googleapis.com"
-build:results --bes_timeout=60s
-build:results --tls_enabled
-
-# Output BES results url
-build:results --bes_results_url="https://source.cloud.google.com/results/invocations/"
-
-# Set flags for uploading to BES without Remote Build Execution.
-build:results-local --bes_backend="buildeventservice.googleapis.com"
-build:results-local --bes_timeout=60s
-build:results-local --tls_enabled=true
-build:results-local --auth_enabled=true
-build:results-local --spawn_strategy=local
-build:results-local --remote_cache=remotebuildexecution.googleapis.com
-build:results-local --remote_timeout=3600
-build:results-local --bes_results_url="https://source.cloud.google.com/results/invocations/"
 
 # The following flags are only necessary for local docker sandboxing
 # with the rbe-ubuntu16-04 container. Use of these flags is still experimental.


### PR DESCRIPTION
The Results UI is not launched, so we shouldn't be referencing it from public bazelrc files.