### PR TITLE
Fix build status badge to show status from master only.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Bazel CI
 :---:
-[![Build status](https://badge.buildkite.com/940075452c1c5ff91dc832664c4c8f05e6ec736916688cd894.svg)](https://buildkite.com/bazel/bazel-toolchains-postsubmit)
+[![Build status](https://badge.buildkite.com/940075452c1c5ff91dc832664c4c8f05e6ec736916688cd894.svg?branch=master)](https://buildkite.com/bazel/bazel-toolchains-postsubmit)
 
 # bazel-toolchains
 


### PR DESCRIPTION
Failures in other branches / PRs will otherwise cause it to turn red. :)