### PR TITLE
fixing bazel rc type in rbe autoconfig

### DIFF
--- a/rules/rbe_repo.bzl
+++ b/rules/rbe_repo.bzl
@@ -593,7 +593,7 @@ def _expand_outputs(ctx, bazel_version, project_root):
 # rule directly, use rbe_autoconfig macro declared below.
 _rbe_autoconfig = repository_rule(
     attrs = {
-        "bazel_rc_version": attr.string(
+        "bazel_rc_version": attr.int(
             doc = ("Optional. An rc version to use. Note an installer for " +
                    "the rc must be available in https://releases.bazel.build."),
         ),


### PR DESCRIPTION
fixing error: "bazel_toolchains/rules/rbe_repo.bzl:793:5: //external:rbe_default: expected value of type 'string' for attribute 'bazel_rc_version' in '_rbe_autoconfig' rule, but got 4 (int)"