### PR TITLE
Replace --genrule_strategy with --strategy=Genrule

### DIFF
--- a/bazelrc/bazel-0.21.0.bazelrc
+++ b/bazelrc/bazel-0.21.0.bazelrc
@@ -59,7 +59,7 @@ build:remote --platforms=@bazel_toolchains//configs/ubuntu16_04_clang/1.1:rbe_ub
 build:remote --spawn_strategy=remote
 build:remote --strategy=Javac=remote
 build:remote --strategy=Closure=remote
-build:remote --genrule_strategy=remote
+build:remote --strategy=Genrule=remote
 build:remote --define=EXECUTOR=remote
 
 # Enable the remote cache so action results can be shared across machines,
@@ -89,7 +89,7 @@ build:docker-sandbox --experimental_docker_image=gcr.io/cloud-marketplace/google
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker
 build:docker-sandbox --strategy=Closure=docker
-build:docker-sandbox --genrule_strategy=docker
+build:docker-sandbox --strategy=Genrule=docker
 build:docker-sandbox --define=EXECUTOR=remote
 build:docker-sandbox --experimental_docker_verbose
 build:docker-sandbox --experimental_enable_docker_sandbox
@@ -103,4 +103,4 @@ build:remote-cache --auth_enabled=true
 build:remote-cache --spawn_strategy=standalone
 build:remote-cache --strategy=Javac=standalone
 build:remote-cache --strategy=Closure=standalone
-build:remote-cache --genrule_strategy=standalone
+build:remote-cache --strategy=Genrule=standalone

--- a/bazelrc/bazel-0.22.0.bazelrc
+++ b/bazelrc/bazel-0.22.0.bazelrc
@@ -59,7 +59,7 @@ build:remote --platforms=@bazel_toolchains//configs/ubuntu16_04_clang/1.1:rbe_ub
 build:remote --spawn_strategy=remote
 build:remote --strategy=Javac=remote
 build:remote --strategy=Closure=remote
-build:remote --genrule_strategy=remote
+build:remote --strategy=Genrule=remote
 build:remote --define=EXECUTOR=remote
 
 # Enable the remote cache so action results can be shared across machines,
@@ -89,7 +89,7 @@ build:docker-sandbox --experimental_docker_image=gcr.io/cloud-marketplace/google
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker
 build:docker-sandbox --strategy=Closure=docker
-build:docker-sandbox --genrule_strategy=docker
+build:docker-sandbox --strategy=Genrule=docker
 build:docker-sandbox --define=EXECUTOR=remote
 build:docker-sandbox --experimental_docker_verbose
 build:docker-sandbox --experimental_enable_docker_sandbox
@@ -103,4 +103,4 @@ build:remote-cache --auth_enabled=true
 build:remote-cache --spawn_strategy=standalone
 build:remote-cache --strategy=Javac=standalone
 build:remote-cache --strategy=Closure=standalone
-build:remote-cache --genrule_strategy=standalone
+build:remote-cache --strategy=Genrule=standalone

--- a/examples/remotebuildexecution/rbe_system_check/.bazelrc.sample
+++ b/examples/remotebuildexecution/rbe_system_check/.bazelrc.sample
@@ -19,7 +19,7 @@
 build:remote --spawn_strategy=remote
 build:remote --strategy=Javac=remote
 build:remote --strategy=Closure=remote
-build:remote --genrule_strategy=remote
+build:remote --strategy=Genrule=remote
 build:remote --define=EXECUTOR=remote
 
 # Enable the remote API flags

--- a/release/bazelrc.tpl
+++ b/release/bazelrc.tpl
@@ -45,7 +45,7 @@ build:remote --platforms=@bazel_toolchains//configs/ubuntu16_04_clang/1.1:rbe_ub
 build:remote --spawn_strategy=remote
 build:remote --strategy=Javac=remote
 build:remote --strategy=Closure=remote
-build:remote --genrule_strategy=remote
+build:remote --strategy=Genrule=remote
 build:remote --define=EXECUTOR=remote
 
 # Enable the remote cache so action results can be shared across machines,


### PR DESCRIPTION
Bazel 0.21.0 and higher have added --strategy=Genrule.
--genrule_strategy does not take effect if --strategy=Genrule is set
causing genrules to not be run remotely.

See-also: https://github.com/bazelbuild/bazel/issues/6760
Signed-off-by: Jason Zaman <jason@perfinion.com>