### PR TITLE
Revert "Enable rbe autoconf for ci"

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -23,8 +23,7 @@ platforms:
     test_flags:
     - "--test_output=errors"
     - "--verbose_failures"
-    - "--crosstool_top=@buildkite_config//cc:toolchain"
-    - "--extra_toolchains=@buildkite_config//config:cc-toolchain"
-    - "--extra_execution_platforms=@bazel_toolchains//configs/ubuntu16_04_clang:platform_docker"
-    - "--host_platform=@bazel_toolchains//configs/ubuntu16_04_clang:platform_docker"
-    - "--platforms=@bazel_toolchains//configs/ubuntu16_04_clang:platform_docker"
+    - "--extra_toolchains=@bazel_toolchains//configs/ubuntu16_04_clang/latest:toolchain_docker"
+    - "--extra_execution_platforms=@bazel_toolchains//configs/ubuntu16_04_clang/latest:platform_docker"
+    - "--host_platform=@bazel_toolchains//configs/ubuntu16_04_clang/latest:platform_docker"
+    - "--platforms=@bazel_toolchains//configs/ubuntu16_04_clang/latest:platform_docker"


### PR DESCRIPTION
Reverts bazelbuild/bazel-toolchains#352

@buildkite_config cannot be used yet.