### PR TITLE
Make java_home optional in rbe_autoconfig

### DIFF
--- a/rules/rbe_repo.bzl
+++ b/rules/rbe_repo.bzl
@@ -831,6 +831,9 @@ def rbe_autoconfig(
     if bazel_rc_version and not bazel_version:
         fail("bazel_rc_version can only be used with bazel_version.")
 
+    if not create_java_configs and java_home != None:
+        fail("java_home should not be set when create_java_configs is false.")
+
     # Resolve the Bazel version to use.
     if not bazel_version or bazel_version == "local":
         bazel_version = str(extract_version_number(_BAZEL_VERSION_FALLBACK))

--- a/rules/rbe_repo.bzl
+++ b/rules/rbe_repo.bzl
@@ -695,18 +695,18 @@ _rbe_autoconfig = repository_rule(
                    "example, [\"@bazel_tools//platforms:linux\"]. Default " +
                    " is set to values for rbe-ubuntu16-04 container."),
         ),
-        "create_java_configs" : attr.bool(
+        "create_java_configs": attr.bool(
             doc = (
                 "Optional. Specifies whether to generate java configs. " +
                 "Defauls to True."
-            )
+            ),
         ),
         "java_home": attr.string(
-            doc = ("Optional. The location of java_home in the container. For "+
-                   "example , '/usr/lib/jvm/java-8-openjdk-amd64'. Only "+
-                   "relevant if 'create_java_configs' is true. If 'create_java_configs' is "+
-                   "true and this attribute is not set, the rule will attempt to read the "+
-                   "JAVA_HOME env var from the container. If that is not set, the rule "+
+            doc = ("Optional. The location of java_home in the container. For " +
+                   "example , '/usr/lib/jvm/java-8-openjdk-amd64'. Only " +
+                   "relevant if 'create_java_configs' is true. If 'create_java_configs' is " +
+                   "true and this attribute is not set, the rule will attempt to read the " +
+                   "JAVA_HOME env var from the container. If that is not set, the rule " +
                    "will fail."),
         ),
         "output_base": attr.string(


### PR DESCRIPTION
Not specifying java_home and specifying a container with a blank
java_home or explicitly specifying a blank java_home attribute results
in skipping over java config generation.