### PR TITLE
Return providers instead of struct from rule impl functions

### DIFF
--- a/rules/container/debian_pkg_tar.bzl
+++ b/rules/container/debian_pkg_tar.bzl
@@ -124,13 +124,11 @@ def _generate_deb_tar(
         output_script = output_script,
     )
 
-    return struct(
-        providers = [
-            InstallableTarInfo(
-                installables_tar = output_tar,
-            ),
-        ],
-    )
+    return [
+        InstallableTarInfo(
+            installables_tar = output_tar,
+        ),
+    ]
 
 def _aggregate_debian_pkgs_impl(ctx):
     """Implementation for the aggregate_debian_pkgs rule.


### PR DESCRIPTION
This addresses the incompatible change via the `--incompatible_disallow_struct_provider_syntax` flag described [here](https://github.com/bazelbuild/bazel/issues/7347).