### PR TITLE
Update to new repo macro for latest rules_go

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -49,7 +49,7 @@ load(
 
 bazel_toolchains_images()
 
-load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
 

--- a/deps/io_bazel_rules_go.bzl
+++ b/deps/io_bazel_rules_go.bzl
@@ -13,4 +13,4 @@
 # limitations under the License.
 """Commit sha for bazelbuild/rules_go."""
 
-version = "2d792dea8d22c552f455623bb15eb4f61fcb2f1b"
+version = "f900a9e520e9fdb7b81511f9aa5de2e43da19e2a"


### PR DESCRIPTION
This is a manual version of #404 because the latest rules_go version
changes the location of the deps macro from //go:def.bzl to
//go:deps.bzl.

IO_BAZEL_RULES_GO_REV_ID: f900a9e520e9fdb7b81511f9aa5de2e43da19e2a