### PR TITLE
Improve rbe autoconf

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -118,7 +118,9 @@ rbe_autoconfig(
 rbe_autoconfig(
     name = "rbe_default_with_output_base",
     config_dir = "default",
-    output_base = "configs/ubuntu16_04_clang/1.1",
+    create_cc_configs = False,
+    external_repos = ["docker_config"],
+    output_base = "tests/temp",
 )
 
 # Targets used by automatic config generation and release service.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -118,7 +118,7 @@ rbe_autoconfig(
 rbe_autoconfig(
     name = "rbe_default_with_output_base",
     config_dir = "default",
-    create_cc_configs = False,
+    output_base = "configs/ubuntu16_04_clang/1.1",
 )
 
 # Targets used by automatic config generation and release service.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -119,8 +119,6 @@ rbe_autoconfig(
     name = "rbe_default_with_output_base",
     config_dir = "default",
     create_cc_configs = False,
-    config_repos = ["docker_config"],
-    output_base = "tests/temp",
 )
 
 # Targets used by automatic config generation and release service.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -119,7 +119,7 @@ rbe_autoconfig(
     name = "rbe_default_with_output_base",
     config_dir = "default",
     create_cc_configs = False,
-    external_repos = ["docker_config"],
+    config_repos = ["docker_config"],
     output_base = "tests/temp",
 )
 

--- a/rules/rbe_repo.bzl
+++ b/rules/rbe_repo.bzl
@@ -233,6 +233,8 @@ def _impl(ctx):
     # If not using checked-in configs we need to pull the container and resolve its tag to digest
     # before we create the platform target.
     if not ctx.attr.config_version:
+        ctx.report_progress("validating host tools")
+
         # Perform some safety checks
         _validate_host(ctx)
         project_root = ctx.os.environ.get(_AUTOCONF_ROOT, None)
@@ -275,6 +277,7 @@ def _impl(ctx):
 
     # Create a default BUILD file with the platform + toolchain targets that
     # will work with RBE with the produced toolchain
+    ctx.report_progress("creating platform")
     _create_platform(
         ctx,
         # Use "marketplace.gcr.io" instead of "l.gcr.io" in platform targets.
@@ -304,6 +307,8 @@ def _impl(ctx):
         project_root = project_root,
         use_default_project = use_default_project,
     )
+
+    ctx.report_progress("expanding outputs")
 
     # Expand outputs to project dir if user requested it
     _expand_outputs(
@@ -375,10 +380,10 @@ def _use_standard_config(ctx):
 
 # Pulls an image using 'docker pull'.
 def _pull_image(ctx, image_name):
-    print("Pulling image %s." % image_name)
+    ctx.report_progress("pulling image %s." % image_name)
     result = ctx.execute(["docker", "pull", image_name])
     _print_exec_results("pull image", result, fail_on_error = True)
-    print("Image pulled.")
+    ctx.report_progress("image pulled.")
 
 # Gets the value of java_home either from attr or
 # by running docker run image_name printenv JAVA_HOME.
@@ -411,6 +416,7 @@ def _get_java_home(ctx, image_name):
 # to run the commands to install bazel, run it and create the output tar
 def _create_docker_cmd(
         ctx,
+        config_repos,
         bazel_version,
         bazel_rc_version,
         outputs_tar,
@@ -437,7 +443,7 @@ def _create_docker_cmd(
     # Needed because some outputs of local_cc_config (e.g., dummy_toolchain.bzl)
     # could be symlinks.
     deref_symlinks_cmd = []
-    for config_repo in _CONFIG_REPOS:
+    for config_repo in config_repos:
         symlinks_cmd = ("find $(bazel info output_base)/" +
                         _EXTERNAL_FOLDER_PREFIX + config_repo +
                         " -type l -exec bash -c 'ln -f \"$(readlink -m \"$0\")\" \"$0\"' {} \;")
@@ -447,7 +453,7 @@ def _create_docker_cmd(
     # Command to copy produced toolchain configs to a tar at the root
     # of the container.
     copy_cmd = ["mkdir " + _OUTPUT_DIR]
-    for config_repo in _CONFIG_REPOS:
+    for config_repo in config_repos:
         src_dir = "$(bazel info output_base)/" + _EXTERNAL_FOLDER_PREFIX + config_repo
         copy_cmd.append("cp -dr " + src_dir + " " + _OUTPUT_DIR)
     copy_cmd.append("tar -cf /" + outputs_tar + " -C " + _OUTPUT_DIR + "/ . ")
@@ -463,7 +469,7 @@ def _create_docker_cmd(
     bazel_cmd = "cd " + _ROOT_DIR + "/" + _PROJECT_REPO_DIR
 
     # For each config repo we run the target @<config_repo>//...
-    bazel_targets = "@" + "//... @".join(_CONFIG_REPOS) + "//..."
+    bazel_targets = "@" + "//... @".join(config_repos) + "//..."
     bazel_cmd += " && bazel build " + bazel_targets
 
     # Command to run to clean up after autoconfiguration.
@@ -497,11 +503,17 @@ def _run_and_extract(
         outputs_tar,
         project_root,
         use_default_project):
+    config_repos = []
+    config_repos.extend(_CONFIG_REPOS)
+    if ctx.attr.external_repos:
+        config_repos.extend(ctx.attr.external_repos)
+
     # Create command to run inside docker container
     _create_docker_cmd(
         ctx,
         bazel_version = bazel_version,
         bazel_rc_version = bazel_rc_version,
+        config_repos = config_repos,
         outputs_tar = outputs_tar,
         use_default_project = use_default_project,
     )
@@ -553,7 +565,7 @@ def _run_and_extract(
     )
 
     # run run_and_extract.sh
-    print("Running container")
+    ctx.report_progress("running container")
     result = ctx.execute(["./run_and_extract.sh"])
     _print_exec_results("run_and_extract", result, fail_on_error = True)
 
@@ -625,7 +637,7 @@ def _expand_outputs(ctx, bazel_version, project_root):
         project_root: The output directory where configs will be copied to.
     """
     if ctx.attr.output_base:
-        print("Copying outputs to project directory")
+        ctx.report_progress("copying outputs to project directory")
         dest = project_root + "/" + ctx.attr.output_base + "/bazel_" + bazel_version + "/"
         if ctx.attr.config_dir:
             dest += ctx.attr.config_dir + "/"
@@ -636,25 +648,25 @@ def _expand_outputs(ctx, bazel_version, project_root):
         # Create the directories
         result = ctx.execute(["mkdir", "-p", platform_dest])
         _print_exec_results("create platform output dir", result)
-        if ctx.attr.create_java_configs:
-            result = ctx.execute(["mkdir", "-p", java_dest])
-            _print_exec_results("create java output dir", result)
-        result = ctx.execute(["mkdir", "-p", cc_dest])
-        _print_exec_results("create cc output dir", result)
-
-        # Get the files that were created in the _CC_CONFIG_DIR
-        ctx.file("local_config_files.sh", ("echo $(find ./%s -type f | sort -n)" % _CC_CONFIG_DIR), True)
-        result = ctx.execute(["./local_config_files.sh"])
-        _print_exec_results("resolve autoconf files", result)
-        autoconf_files = result.stdout.splitlines()[0].split(" ")
-        args = ["cp"] + autoconf_files + [cc_dest]
 
         # Copy the local_config_cc files to dest/{_CC_CONFIG_DIR}/
-        result = ctx.execute(args)
-        _print_exec_results("copy local_config_cc outputs", result, True, args)
+        if ctx.attr.create_cc_configs:
+            result = ctx.execute(["mkdir", "-p", cc_dest])
+            _print_exec_results("create cc output dir", result)
+
+            # Get the files that were created in the _CC_CONFIG_DIR
+            ctx.file("local_config_files.sh", ("echo $(find ./%s -type f | sort -n)" % _CC_CONFIG_DIR), True)
+            result = ctx.execute(["./local_config_files.sh"])
+            _print_exec_results("resolve autoconf files", result)
+            autoconf_files = result.stdout.splitlines()[0].split(" ")
+            args = ["cp"] + autoconf_files + [cc_dest]
+            result = ctx.execute(args)
+            _print_exec_results("copy local_config_cc outputs", result, True, args)
 
         # Copy the dest/{_JAVA_CONFIG_DIR}/BUILD file
         if ctx.attr.create_java_configs:
+            result = ctx.execute(["mkdir", "-p", java_dest])
+            _print_exec_results("create java output dir", result)
             args = ["cp", str(ctx.path(_JAVA_CONFIG_DIR + "/BUILD")), java_dest]
             result = ctx.execute(args)
             _print_exec_results("copy java_runtime BUILD", result, True, args)
@@ -663,6 +675,22 @@ def _expand_outputs(ctx, bazel_version, project_root):
         args = ["cp", str(ctx.path(_PLATFORM_DIR + "/BUILD")), platform_dest]
         result = ctx.execute(args)
         _print_exec_results("copy platform BUILD", result, True, args)
+
+        # Copy any additional external repos that were requested
+        if ctx.attr.external_repos:
+            for repo in ctx.attr.external_repos:
+                repo_dest = dest + repo + "/"
+                result = ctx.execute(["mkdir", "-p", repo_dest])
+                _print_exec_results("create %s output dir" % repo, result)
+
+                # Get the files that were created in the repo dir
+                ctx.file(repo + "_config_files.sh", ("echo $(find ./%s -type f | sort -n)" % repo), True)
+                result = ctx.execute(["./" + repo + "_config_files.sh"])
+                _print_exec_results("resolve %s repo files" % repo, result)
+                repo_files = result.stdout.splitlines()[0].split(" ")
+                args = ["cp"] + repo_files + [repo_dest]
+                result = ctx.execute(args)
+                _print_exec_results("copy %s repo files" % repo, result, True, args)
 
 # Private declaration of _rbe_autoconfig repository rule. Do not use this
 # rule directly, use rbe_autoconfig macro declared below.
@@ -710,6 +738,12 @@ _rbe_autoconfig = repository_rule(
                 "supported or allowed on the system."
             ),
         ),
+        "create_cc_configs": attr.bool(
+            doc = (
+                "Optional. Specifies whether to generate C/C++ configs. " +
+                "Defauls to True."
+            ),
+        ),
         "create_java_configs": attr.bool(
             doc = (
                 "Optional. Specifies whether to generate java configs. " +
@@ -734,6 +768,11 @@ _rbe_autoconfig = repository_rule(
                    "the platform in its constraint_values attr). For " +
                    "example, [\"@bazel_tools//platforms:linux\"]. Default " +
                    " is set to values for rbe-ubuntu16-04 container."),
+        ),
+        "external_repos": attr.string_list(
+            doc = ("Optional. list of additional external repos corresponding to " +
+                   "configure like repo rules that need to be produced in addition to " +
+                   "local_config_cc."),
         ),
         "java_home": attr.string(
             doc = ("Optional. The location of java_home in the container. For " +
@@ -791,6 +830,8 @@ def rbe_autoconfig(
         digest = None,
         env = None,
         exec_compatible_with = None,
+        external_repos = None,
+        create_cc_configs = True,
         create_java_configs = True,
         java_home = None,
         output_base = None,
@@ -826,9 +867,6 @@ def rbe_autoconfig(
       digest: Optional. The digest of the image to pull.
           Should not be set if tag is used.
           Must be set together with registry and repository.
-      exec_compatible_with: Optional. List of constraints to add to the produced
-          toolchain/platform targets (e.g., ["@bazel_tools//platforms:linux"] in the
-          exec_compatible_with/constraint_values attrs, respectively.
       env: dict. Optional. Additional env variables that will be set when
           running the Bazel command to generate the toolchain configs.
           Set to values for marketplace.gcr.io/google/rbe-ubuntu16-04 container.
@@ -836,6 +874,14 @@ def rbe_autoconfig(
           the rbe-ubuntu16-04 container.
           Should be overriden if a custom container does not extend the
           rbe-ubuntu16-04 container.
+      exec_compatible_with: Optional. List of constraints to add to the produced
+          toolchain/platform targets (e.g., ["@bazel_tools//platforms:linux"] in the
+          exec_compatible_with/constraint_values attrs, respectively.
+      exteral_repos: Optional. list of additional external repos corresponding to
+          configure like repo rules that need to be produced in addition to
+          local_config_cc
+      create_cc_configs: Optional. Specifies whether to generate C/C++ configs.
+          Defauls to True.
       create_java_configs: Optional. Specifies whether to generate java configs.
           Defauls to True.
       java_home: Optional. The location of java_home in the container. For
@@ -907,9 +953,9 @@ def rbe_autoconfig(
         base_container_digest = base_container_digest,
         bazel_version = bazel_version,
         bazel_rc_version = bazel_rc_version,
+        create_java_configs = create_java_configs,
         digest = digest,
         env = env,
-        create_java_configs = create_java_configs,
         java_home = java_home,
         registry = registry,
         repository = repository,
@@ -925,10 +971,12 @@ def rbe_autoconfig(
         config_dir = config_dir,
         config_version = config_version,
         copy_resources = copy_resources,
+        create_cc_configs = create_cc_configs,
+        create_java_configs = create_java_configs,
         digest = digest,
         env = env,
         exec_compatible_with = exec_compatible_with,
-        create_java_configs = create_java_configs,
+        external_repos = external_repos,
         java_home = java_home,
         output_base = output_base,
         registry = registry,
@@ -942,9 +990,9 @@ def validateUseOfCheckedInConfigs(
         base_container_digest,
         bazel_version,
         bazel_rc_version,
+        create_java_configs,
         digest,
         env,
-        create_java_configs,
         java_home,
         registry,
         repository,

--- a/tests/rules/BUILD
+++ b/tests/rules/BUILD
@@ -1,3 +1,17 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 load(
     "@bazel_tools//tools/build_rules:test_rules.bzl",
     "file_test",


### PR DESCRIPTION
Improve feature parity with docker_autoconfig:

* This PR adds capability to extract more external repos from the docker container. 
* Repos are specified via `config_repos` attr (same name as in docker_autoconfig)

Tested locally. Will prepare this week a PR to improve unit testing overall for this rule.