### PR TITLE
Rbe autoconf tests

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -12,6 +12,9 @@ platforms:
   rbe_ubuntu1604:
     test_targets:
     - "//tests/config:ubuntu-xenial-autoconfig_test"
+    - "//tests/rbe_repo:rac_checked_in_test"
+    - "//tests/rbe_repo:rac_checked_in_no_java_test"
+    - "//tests/rbe_repo:rac_checked_in_no_cc_test"
     # TODO(nlopezgi): reenable this test once bazel 0.19.2 is out
     #- "//tests/config:ubuntu-xenial-bazel-head-autoconfig_test"
     - "//tests/config:ubuntu-xenial-custom-bazel-rc-version-autoconfig_test"
@@ -21,6 +24,7 @@ platforms:
     - "//configs/ubuntu16_04_clang:default-ubuntu16_04-clang-1.1-bazel_0.18.0-autoconfig_test"
     - "//configs/ubuntu16_04_clang:msan-ubuntu16_04-clang-1.1-bazel_0.18.0-autoconfig_test"
     test_flags:
+    - "--loading_phase_threads=1"
     - "--test_output=errors"
     - "--verbose_failures"
     - "--extra_toolchains=@bazel_toolchains//configs/ubuntu16_04_clang/latest:toolchain_docker"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -24,10 +24,11 @@ platforms:
     - "//configs/ubuntu16_04_clang:default-ubuntu16_04-clang-1.1-bazel_0.18.0-autoconfig_test"
     - "//configs/ubuntu16_04_clang:msan-ubuntu16_04-clang-1.1-bazel_0.18.0-autoconfig_test"
     test_flags:
-    - "--loading_phase_threads=1"
     - "--test_output=errors"
     - "--verbose_failures"
     - "--extra_toolchains=@bazel_toolchains//configs/ubuntu16_04_clang/latest:toolchain_docker"
     - "--extra_execution_platforms=@bazel_toolchains//configs/ubuntu16_04_clang/latest:platform_docker"
     - "--host_platform=@bazel_toolchains//configs/ubuntu16_04_clang/latest:platform_docker"
     - "--platforms=@bazel_toolchains//configs/ubuntu16_04_clang/latest:platform_docker"
+    # TODO(nlopezgi): remove this flag once rbe_autoconfig can be run in parallel
+    - "--loading_phase_threads=1"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -12,9 +12,9 @@ platforms:
   rbe_ubuntu1604:
     test_targets:
     - "//tests/config:ubuntu-xenial-autoconfig_test"
-    - "//tests/rbe_repo:rac_checked_in_test"
-    - "//tests/rbe_repo:rac_checked_in_no_java_test"
-    - "//tests/rbe_repo:rac_checked_in_no_cc_test"
+    - "//tests/rbe_repo:rbe_autoconf_checked_in_test"
+    - "//tests/rbe_repo:rbe_autoconf_checked_in_no_java_test"
+    - "//tests/rbe_repo:rbe_autoconf_checked_in_no_cc_test"
     # TODO(nlopezgi): reenable this test once bazel 0.19.2 is out
     #- "//tests/config:ubuntu-xenial-bazel-head-autoconfig_test"
     - "//tests/config:ubuntu-xenial-custom-bazel-rc-version-autoconfig_test"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -192,22 +192,22 @@ rbe_autoconfig(
 rbe_autoconfig(
     name = "rac_generate",
     bazel_version = _ubuntu1604_bazel,
-    use_checked_in_confs = False,
     create_testdata = True,
+    use_checked_in_confs = False,
 )
 
 rbe_autoconfig(
     name = "rac_generate_no_java",
     bazel_version = _ubuntu1604_bazel,
     create_java_configs = False,
-    use_checked_in_confs = False,
     create_testdata = True,
+    use_checked_in_confs = False,
 )
 
 rbe_autoconfig(
     name = "rac_generate_no_cc",
     bazel_version = _ubuntu1604_bazel,
     create_cc_configs = False,
-    use_checked_in_confs = False,
     create_testdata = True,
+    use_checked_in_confs = False,
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -118,7 +118,9 @@ rbe_autoconfig(
 rbe_autoconfig(
     name = "rbe_default_with_output_base",
     config_dir = "default",
-    output_base = "configs/ubuntu16_04_clang/1.1",
+    create_cc_configs = False,
+    external_repos = ["docker_config"],
+    output_base = "tests/temp",
 )
 
 # Targets used by automatic config generation and release service.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -170,34 +170,34 @@ rbe_autoconfig(
 # Targets below for purposes of testing of rbe_autoconfig rule only
 
 rbe_autoconfig(
-    name = "rac_checked_in",
+    name = "rbe_autoconf_checked_in",
     bazel_version = _ubuntu1604_bazel,
     create_testdata = True,
 )
 
 rbe_autoconfig(
-    name = "rac_checked_in_no_java",
+    name = "rbe_autoconf_checked_in_no_java",
     bazel_version = _ubuntu1604_bazel,
     create_java_configs = False,
     create_testdata = True,
 )
 
 rbe_autoconfig(
-    name = "rac_checked_in_no_cc",
+    name = "rbe_autoconf_checked_in_no_cc",
     bazel_version = _ubuntu1604_bazel,
     create_cc_configs = False,
     create_testdata = True,
 )
 
 rbe_autoconfig(
-    name = "rac_generate",
+    name = "rbe_autoconf_generate",
     bazel_version = _ubuntu1604_bazel,
     create_testdata = True,
     use_checked_in_confs = False,
 )
 
 rbe_autoconfig(
-    name = "rac_generate_no_java",
+    name = "rbe_autoconf_generate_no_java",
     bazel_version = _ubuntu1604_bazel,
     create_java_configs = False,
     create_testdata = True,
@@ -205,7 +205,7 @@ rbe_autoconfig(
 )
 
 rbe_autoconfig(
-    name = "rac_generate_no_cc",
+    name = "rbe_autoconf_generate_no_cc",
     bazel_version = _ubuntu1604_bazel,
     create_cc_configs = False,
     create_testdata = True,

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -119,8 +119,6 @@ rbe_autoconfig(
     name = "rbe_default_with_output_base",
     config_dir = "default",
     create_cc_configs = False,
-    config_repos = ["docker_config"],
-    output_base = "tests/temp",
 )
 
 # Targets used by automatic config generation and release service.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -119,7 +119,7 @@ rbe_autoconfig(
     name = "rbe_default_with_output_base",
     config_dir = "default",
     create_cc_configs = False,
-    external_repos = ["docker_config"],
+    config_repos = ["docker_config"],
     output_base = "tests/temp",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -103,22 +103,9 @@ gcs_file(
 
 load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
 
-rbe_autoconfig(name = "rbe_default")
-
-rbe_autoconfig(
-    name = "rbe_default_no_checked_in_confs",
-    use_checked_in_confs = False,
-)
-
 rbe_autoconfig(
     name = "rbe_default_copy_resources",
     copy_resources = True,
-)
-
-rbe_autoconfig(
-    name = "rbe_default_with_output_base",
-    config_dir = "default",
-    create_cc_configs = False,
 )
 
 # Targets used by automatic config generation and release service.
@@ -178,4 +165,49 @@ rbe_autoconfig(
     env = clang_env(),
     registry = "gcr.io",
     repository = "asci-toolchain/nosla-ubuntu16_04-bazel-docker-gcloud",
+)
+
+# Targets below for purposes of testing of rbe_autoconfig rule only
+
+rbe_autoconfig(
+    name = "rac_checked_in",
+    bazel_version = _ubuntu1604_bazel,
+    create_testdata = True,
+)
+
+rbe_autoconfig(
+    name = "rac_checked_in_no_java",
+    bazel_version = _ubuntu1604_bazel,
+    create_java_configs = False,
+    create_testdata = True,
+)
+
+rbe_autoconfig(
+    name = "rac_checked_in_no_cc",
+    bazel_version = _ubuntu1604_bazel,
+    create_cc_configs = False,
+    create_testdata = True,
+)
+
+rbe_autoconfig(
+    name = "rac_generate",
+    bazel_version = _ubuntu1604_bazel,
+    use_checked_in_confs = False,
+    create_testdata = True,
+)
+
+rbe_autoconfig(
+    name = "rac_generate_no_java",
+    bazel_version = _ubuntu1604_bazel,
+    create_java_configs = False,
+    use_checked_in_confs = False,
+    create_testdata = True,
+)
+
+rbe_autoconfig(
+    name = "rac_generate_no_cc",
+    bazel_version = _ubuntu1604_bazel,
+    create_cc_configs = False,
+    use_checked_in_confs = False,
+    create_testdata = True,
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -103,6 +103,8 @@ gcs_file(
 
 load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
 
+rbe_autoconfig(name = "rbe_default")
+
 rbe_autoconfig(
     name = "rbe_default_copy_resources",
     copy_resources = True,

--- a/rules/rbe_repo.bzl
+++ b/rules/rbe_repo.bzl
@@ -735,7 +735,9 @@ filegroup(
 )
 """, False)
 
-    # create an empty file to reference in tests
+    # Create an empty file to reference in test.
+    # This is needed for tests to reference the location
+    # of all test outputs.
     ctx.file("test/empty", "", False)
 
 # Private declaration of _rbe_autoconfig repository rule. Do not use this

--- a/rules/rbe_repo.bzl
+++ b/rules/rbe_repo.bzl
@@ -774,11 +774,6 @@ _rbe_autoconfig = repository_rule(
                    "example, [\"@bazel_tools//platforms:linux\"]. Default " +
                    " is set to values for rbe-ubuntu16-04 container."),
         ),
-        "external_repos": attr.string_list(
-            doc = ("Optional. list of additional external repos corresponding to " +
-                   "configure like repo rules that need to be produced in addition to " +
-                   "local_config_cc."),
-        ),
         "java_home": attr.string(
             doc = ("Optional. The location of java_home in the container. For " +
                    "example , '/usr/lib/jvm/java-8-openjdk-amd64'. Only " +

--- a/rules/rbe_repo.bzl
+++ b/rules/rbe_repo.bzl
@@ -774,6 +774,11 @@ _rbe_autoconfig = repository_rule(
                    "example, [\"@bazel_tools//platforms:linux\"]. Default " +
                    " is set to values for rbe-ubuntu16-04 container."),
         ),
+        "external_repos": attr.string_list(
+            doc = ("Optional. list of additional external repos corresponding to " +
+                   "configure like repo rules that need to be produced in addition to " +
+                   "local_config_cc."),
+        ),
         "java_home": attr.string(
             doc = ("Optional. The location of java_home in the container. For " +
                    "example , '/usr/lib/jvm/java-8-openjdk-amd64'. Only " +

--- a/rules/rbe_repo.bzl
+++ b/rules/rbe_repo.bzl
@@ -582,6 +582,10 @@ def _run_and_extract(
     # Expand outputs inside this remote repo
     result = ctx.execute(["tar", "-xf", "output.tar"])
     _print_exec_results("expand_tar", result)
+    # TODO(ngiraldo): If user does not want cc_configs generated, we are
+    # currently still producing them in the container, but deleting them here.
+    # We actually need to not produce them (and make sure Bazel command does
+    # not fail in the process).
     if ctx.attr.create_cc_configs:
         result = ctx.execute(["mv", "./local_config_cc", ("./%s" % _CC_CONFIG_DIR)])
         _print_exec_results("move local_config_cc files", result)

--- a/rules/rbe_repo.bzl
+++ b/rules/rbe_repo.bzl
@@ -582,6 +582,7 @@ def _run_and_extract(
     # Expand outputs inside this remote repo
     result = ctx.execute(["tar", "-xf", "output.tar"])
     _print_exec_results("expand_tar", result)
+
     # TODO(ngiraldo): If user does not want cc_configs generated, we are
     # currently still producing them in the container, but deleting them here.
     # We actually need to not produce them (and make sure Bazel command does

--- a/rules/rbe_repo.bzl
+++ b/rules/rbe_repo.bzl
@@ -717,7 +717,7 @@ def _copy_to_test_dir(ctx):
     _print_exec_results("copy test output files", result, True, args)
 
     # Rename BUILD files
-    ctx.file("rename_build_files.sh", "find ./test -name \"BUILD\" -exec sh -c 'mv \"$1\" \"$(dirname $1)/stub.BUILD\"' _ {} \;", True)
+    ctx.file("rename_build_files.sh", "find ./test -name \"BUILD\" -exec sh -c 'mv \"$1\" \"$(dirname $1)/test.BUILD\"' _ {} \;", True)
     result = ctx.execute(["./rename_build_files.sh"])
     _print_exec_results("Rename BUILD files in test output", result, True, args)
 

--- a/rules/rbe_repo.bzl
+++ b/rules/rbe_repo.bzl
@@ -321,6 +321,9 @@ def _impl(ctx):
         project_root = project_root,
     )
 
+    # TODO(nlopezgi): refactor call to _copy_to_test_dir
+    # so that its not needed to be duplicated here and
+    # above.
     # Copy all outputs to the test directory
     if ctx.attr.create_testdata:
         _copy_to_test_dir(ctx)

--- a/rules/rbe_repo.bzl
+++ b/rules/rbe_repo.bzl
@@ -706,12 +706,11 @@ def _expand_outputs(ctx, bazel_version, project_root):
                 result = ctx.execute(args)
                 _print_exec_results("copy %s repo files" % repo, result, True, args)
 
-# copies all contents of the external repo to a test directory
-# modifies name of all BUILD files
+# Copies all contents of the external repo to a test directory,
+# modifies name of all BUILD files (to enable file_test to operate on them), and
 # creates a root BUILD file in test directory with a filegroup that contains
 # all files.
 def _copy_to_test_dir(ctx):
-
     # Copy all files with rsync
     args = ["rsync", "-aR", "--exclude='test/empty'", "./", "./test"]
     result = ctx.execute(args)
@@ -731,7 +730,7 @@ filegroup(
 )
 """, False)
 
-    # create an empty file
+    # create an empty file to reference in tests
     ctx.file("test/empty", "", False)
 
 # Private declaration of _rbe_autoconfig repository rule. Do not use this

--- a/rules/rbe_repo.bzl
+++ b/rules/rbe_repo.bzl
@@ -716,7 +716,7 @@ def _expand_outputs(ctx, bazel_version, project_root):
 # all files.
 def _copy_to_test_dir(ctx):
     # Copy all files with rsync
-    args = ["rsync", "-aR", "--exclude='test/empty'", "./", "./test"]
+    args = ["rsync", "-aR", "./", "./test"]
     result = ctx.execute(args)
     _print_exec_results("copy test output files", result, True, args)
 

--- a/tests/rbe_repo/BUILD
+++ b/tests/rbe_repo/BUILD
@@ -1,0 +1,35 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load(
+    "@bazel_tools//tools/build_rules:test_rules.bzl",
+    "file_test",
+)
+
+file_test(
+    name = "rbe_default_no_checked_in_confs_cc_wrapper_test",
+    file = "@rbe_default_no_checked_in_confs//cc:cc_wrapper.sh",
+    regexp = "/usr/local/bin/clang",
+)
+
+file_test(
+    name = "rbe_default_no_checked_in_confs_cc_toolchain_config_test",
+    file = "@rbe_default_no_checked_in_confs//cc:cc_toolchain_config.bzl",
+    regexp = "/usr/local/bin/clang",
+)
+
+# Shell tests that run find inside a given rbe_autoconfig repo and check the
+# found files match the expectation
+
+

--- a/tests/rbe_repo/BUILD
+++ b/tests/rbe_repo/BUILD
@@ -16,98 +16,98 @@
 # right file structure in the external folder repo
 
 sh_test(
-    name = "rac_checked_in_test",
+    name = "rbe_autoconf_checked_in_test",
     srcs = [":rbe_autoconf_checks.sh"],
     args = [
-        "$(location @rac_checked_in//test:empty)",
+        "$(location @rbe_autoconf_checked_in//test:empty)",
         "assert_basic_cofig",
         "assert_checked_in_confs",
         "assert_checked_in_cc_confs",
         "assert_java_confs",
     ],
     data = [
-        "@rac_checked_in//test:empty",
-        "@rac_checked_in//test:exported_testdata",
+        "@rbe_autoconf_checked_in//test:empty",
+        "@rbe_autoconf_checked_in//test:exported_testdata",
     ],
 )
 
 sh_test(
-    name = "rac_checked_in_no_java_test",
+    name = "rbe_autoconf_checked_in_no_java_test",
     srcs = [":rbe_autoconf_checks.sh"],
     args = [
-        "$(location @rac_checked_in_no_java//test:empty)",
+        "$(location @rbe_autoconf_checked_in_no_java//test:empty)",
         "assert_basic_cofig",
         "assert_checked_in_confs",
         "assert_checked_in_cc_confs",
         "assert_no_java_confs",
     ],
     data = [
-        "@rac_checked_in_no_java//test:empty",
-        "@rac_checked_in_no_java//test:exported_testdata",
+        "@rbe_autoconf_checked_in_no_java//test:empty",
+        "@rbe_autoconf_checked_in_no_java//test:exported_testdata",
     ],
 )
 
 sh_test(
-    name = "rac_checked_in_no_cc_test",
+    name = "rbe_autoconf_checked_in_no_cc_test",
     srcs = [":rbe_autoconf_checks.sh"],
     args = [
-        "$(location @rac_checked_in_no_cc//test:empty)",
+        "$(location @rbe_autoconf_checked_in_no_cc//test:empty)",
         "assert_basic_cofig",
         "assert_checked_in_confs",
         "assert_no_cc_confs",
         "assert_java_confs",
     ],
     data = [
-        "@rac_checked_in_no_cc//test:empty",
-        "@rac_checked_in_no_cc//test:exported_testdata",
+        "@rbe_autoconf_checked_in_no_cc//test:empty",
+        "@rbe_autoconf_checked_in_no_cc//test:exported_testdata",
     ],
 )
 
 sh_test(
-    name = "rac_generate_test",
+    name = "rbe_autoconf_generate_test",
     srcs = [":rbe_autoconf_checks.sh"],
     args = [
-        "$(location @rac_generate//test:empty)",
+        "$(location @rbe_autoconf_generate//test:empty)",
         "assert_basic_cofig",
         "assert_no_checked_in_confs",
         "assert_cc_confs",
         "assert_java_confs",
     ],
     data = [
-        "@rac_generate//test:empty",
-        "@rac_generate//test:exported_testdata",
+        "@rbe_autoconf_generate//test:empty",
+        "@rbe_autoconf_generate//test:exported_testdata",
     ],
 )
 
 sh_test(
-    name = "rac_generate_no_java_test",
+    name = "rbe_autoconf_generate_no_java_test",
     srcs = [":rbe_autoconf_checks.sh"],
     args = [
-        "$(location @rac_generate_no_java//test:empty)",
+        "$(location @rbe_autoconf_generate_no_java//test:empty)",
         "assert_basic_cofig",
         "assert_no_checked_in_confs",
         "assert_cc_confs",
         "assert_no_java_confs",
     ],
     data = [
-        "@rac_generate_no_java//test:empty",
-        "@rac_generate_no_java//test:exported_testdata",
+        "@rbe_autoconf_generate_no_java//test:empty",
+        "@rbe_autoconf_generate_no_java//test:exported_testdata",
     ],
 )
 
 sh_test(
-    name = "rac_generate_no_cc_test",
+    name = "rbe_autoconf_generate_no_cc_test",
     srcs = [":rbe_autoconf_checks.sh"],
     args = [
-        "$(location @rac_generate_no_cc//test:empty)",
+        "$(location @rbe_autoconf_generate_no_cc//test:empty)",
         "assert_basic_cofig",
         "assert_no_checked_in_confs",
         "assert_no_cc_confs",
         "assert_java_confs",
     ],
     data = [
-        "@rac_generate_no_cc//test:empty",
-        "@rac_generate_no_cc//test:exported_testdata",
+        "@rbe_autoconf_generate_no_cc//test:empty",
+        "@rbe_autoconf_generate_no_cc//test:exported_testdata",
     ],
 )
 

--- a/tests/rbe_repo/BUILD
+++ b/tests/rbe_repo/BUILD
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# sh_tests below verify that the rbe_autoconfig targets have the
+# right file structure in the external folder repo
+
 sh_test(
     name = "rac_checked_in_test",
     srcs = [":rbe_autoconf_checks.sh"],
@@ -107,3 +110,7 @@ sh_test(
         "@rac_generate_no_cc//test:exported_testdata",
     ],
 )
+
+# TODO(nlopezgi): Add tests that verify the contents of the produced BUILD files (alias vs targets)
+# TODO(nlopezgi): Add tests that verify files were copied to output_folder
+# TODO(nlopezgi): Add tests that verify copy_resources does not mount (check script)

--- a/tests/rbe_repo/BUILD
+++ b/tests/rbe_repo/BUILD
@@ -12,24 +12,98 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load(
-    "@bazel_tools//tools/build_rules:test_rules.bzl",
-    "file_test",
+sh_test(
+    name = "rac_checked_in_test",
+    srcs = [":rbe_autoconf_checks.sh"],
+    args = [
+        "$(location @rac_checked_in//test:empty)",
+        "assert_basic_cofig",
+        "assert_checked_in_confs",
+        "assert_cc_confs",
+        "assert_java_confs",
+    ],
+    data = [
+        "@rac_checked_in//test:empty",
+        "@rac_checked_in//test:exported_testdata",
+    ],
 )
 
-file_test(
-    name = "rbe_default_no_checked_in_confs_cc_wrapper_test",
-    file = "@rbe_default_no_checked_in_confs//cc:cc_wrapper.sh",
-    regexp = "/usr/local/bin/clang",
+sh_test(
+    name = "rac_checked_in_no_java_test",
+    srcs = [":rbe_autoconf_checks.sh"],
+    args = [
+        "$(location @rac_checked_in_no_java//test:empty)",
+        "assert_basic_cofig",
+        "assert_checked_in_confs",
+        "assert_cc_confs",
+        "assert_no_java_confs",
+    ],
+    data = [
+        "@rac_checked_in_no_java//test:empty",
+        "@rac_checked_in_no_java//test:exported_testdata",
+    ],
 )
 
-file_test(
-    name = "rbe_default_no_checked_in_confs_cc_toolchain_config_test",
-    file = "@rbe_default_no_checked_in_confs//cc:cc_toolchain_config.bzl",
-    regexp = "/usr/local/bin/clang",
+sh_test(
+    name = "rac_checked_in_no_cc_test",
+    srcs = [":rbe_autoconf_checks.sh"],
+    args = [
+        "$(location @rac_checked_in_no_cc//test:empty)",
+        "assert_basic_cofig",
+        "assert_checked_in_confs",
+        "assert_no_cc_confs",
+        "assert_java_confs",
+    ],
+    data = [
+        "@rac_checked_in_no_cc//test:empty",
+        "@rac_checked_in_no_cc//test:exported_testdata",
+    ],
 )
 
-# Shell tests that run find inside a given rbe_autoconfig repo and check the
-# found files match the expectation
+sh_test(
+    name = "rac_generate_test",
+    srcs = [":rbe_autoconf_checks.sh"],
+    args = [
+        "$(location @rac_generate//test:empty)",
+        "assert_basic_cofig",
+        "assert_no_checked_in_confs",
+        "assert_cc_confs",
+        "assert_java_confs",
+    ],
+    data = [
+        "@rac_generate//test:empty",
+        "@rac_generate//test:exported_testdata",
+    ],
+)
 
+sh_test(
+    name = "rac_generate_no_java_test",
+    srcs = [":rbe_autoconf_checks.sh"],
+    args = [
+        "$(location @rac_generate_no_java//test:empty)",
+        "assert_basic_cofig",
+        "assert_no_checked_in_confs",
+        "assert_cc_confs",
+        "assert_no_java_confs",
+    ],
+    data = [
+        "@rac_generate_no_java//test:empty",
+        "@rac_generate_no_java//test:exported_testdata",
+    ],
+)
 
+sh_test(
+    name = "rac_generate_no_cc_test",
+    srcs = [":rbe_autoconf_checks.sh"],
+    args = [
+        "$(location @rac_generate_no_cc//test:empty)",
+        "assert_basic_cofig",
+        "assert_no_checked_in_confs",
+        "assert_no_cc_confs",
+        "assert_java_confs",
+    ],
+    data = [
+        "@rac_generate_no_cc//test:empty",
+        "@rac_generate_no_cc//test:exported_testdata",
+    ],
+)

--- a/tests/rbe_repo/BUILD
+++ b/tests/rbe_repo/BUILD
@@ -22,7 +22,7 @@ sh_test(
         "$(location @rac_checked_in//test:empty)",
         "assert_basic_cofig",
         "assert_checked_in_confs",
-        "assert_cc_confs",
+        "assert_checked_in_cc_confs",
         "assert_java_confs",
     ],
     data = [
@@ -38,7 +38,7 @@ sh_test(
         "$(location @rac_checked_in_no_java//test:empty)",
         "assert_basic_cofig",
         "assert_checked_in_confs",
-        "assert_cc_confs",
+        "assert_checked_in_cc_confs",
         "assert_no_java_confs",
     ],
     data = [

--- a/tests/rbe_repo/rbe_autoconf_checks.sh
+++ b/tests/rbe_repo/rbe_autoconf_checks.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+#
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+assert_file_not_exists() {
+  FILE=$1
+  if [ ! -f $FILE ]; then
+    echo "File $FILE does not exist."
+    echo "Passed"
+  else
+    echo "Failed: $FILE exists."
+    exit 1
+  fi
+}
+
+assert_file_exists() {
+  FILE=$1
+  if [ ! -f $FILE ]; then
+    echo "File $FILE does not exist."
+    exit 1
+  else
+    echo "Failed: $FILE exists."
+    echo "Passed"
+  fi
+}
+
+# Checks the config BUILD file was created
+assert_basic_cofig() {
+  assert_file_exists ${DIR}/config/stub.BUILD
+}
+
+# Checks that files not needed when using checked-in
+# configs are not generated
+assert_checked_in_confs() {
+  assert_file_not_exists ${DIR}/output.tar
+  assert_file_not_exists ${DIR}/run_and_extract.sh
+}
+
+# Checks that files needed when creating configs
+# were generated
+assert_no_checked_in_confs() {
+  assert_file_exists ${DIR}/output.tar
+  assert_file_exists ${DIR}/run_and_extract.sh
+  assert_file_exists ${DIR}/container/run_in_container.sh
+}
+
+# Checks that java config files were generated
+assert_java_confs() {
+  assert_file_exists ${DIR}/java/stub.BUILD
+}
+
+# Checks that java config files were not generated
+assert_no_java_confs() {
+  assert_file_not_exists ${DIR}/java/stub.BUILD
+}
+
+# Checks that cc config files were generated
+assert_cc_confs() {
+  assert_file_exists ${DIR}/cc/stub.BUILD
+  assert_file_exists ${DIR}/cc/cc_toolchain_config.bzl
+  assert_file_exists ${DIR}/cc/dummy_toolchain.bzl
+  assert_file_exists ${DIR}/cc/cc_wrapper.sh
+}
+
+# Checks that cc config files were not generated
+assert_no_cc_confs() {
+  assert_file_not_exists ${DIR}/cc/stub.BUILD
+  assert_file_not_exists ${DIR}/cc/cc_toolchain_config.bzl
+  assert_file_not_exists ${DIR}/cc/dummy_toolchain.bzl
+  assert_file_not_exists ${DIR}/cc/cc_wrapper.sh
+}
+
+EMPTY_FILE=$1
+DIR=$(dirname "${EMPTY_FILE}")
+for var in "$@"
+do
+  if [ "$var" != "$1" ]; then
+    $var
+  fi
+done
+

--- a/tests/rbe_repo/rbe_autoconf_checks.sh
+++ b/tests/rbe_repo/rbe_autoconf_checks.sh
@@ -79,6 +79,14 @@ assert_cc_confs() {
   assert_file_exists ${DIR}/cc/cc_wrapper.sh
 }
 
+# Checks that cc config files were generated
+assert_checked_in_cc_confs() {
+  assert_file_exists ${DIR}/cc/stub.BUILD
+  assert_file_not_exists ${DIR}/cc/cc_toolchain_config.bzl
+  assert_file_not_exists ${DIR}/cc/dummy_toolchain.bzl
+  assert_file_not_exists ${DIR}/cc/cc_wrapper.sh
+}
+
 # Checks that cc config files were not generated
 assert_no_cc_confs() {
   assert_file_not_exists ${DIR}/cc/stub.BUILD

--- a/tests/rbe_repo/rbe_autoconf_checks.sh
+++ b/tests/rbe_repo/rbe_autoconf_checks.sh
@@ -43,7 +43,7 @@ assert_file_exists() {
 
 # Checks the config BUILD file was created
 assert_basic_cofig() {
-  assert_file_exists ${DIR}/config/stub.BUILD
+  assert_file_exists ${DIR}/config/test.BUILD
 }
 
 # Checks that files not needed when using checked-in
@@ -63,17 +63,17 @@ assert_no_checked_in_confs() {
 
 # Checks that java config files were generated
 assert_java_confs() {
-  assert_file_exists ${DIR}/java/stub.BUILD
+  assert_file_exists ${DIR}/java/test.BUILD
 }
 
 # Checks that java config files were not generated
 assert_no_java_confs() {
-  assert_file_not_exists ${DIR}/java/stub.BUILD
+  assert_file_not_exists ${DIR}/java/test.BUILD
 }
 
 # Checks that cc config files were generated
 assert_cc_confs() {
-  assert_file_exists ${DIR}/cc/stub.BUILD
+  assert_file_exists ${DIR}/cc/test.BUILD
   assert_file_exists ${DIR}/cc/cc_toolchain_config.bzl
   assert_file_exists ${DIR}/cc/dummy_toolchain.bzl
   assert_file_exists ${DIR}/cc/cc_wrapper.sh
@@ -81,7 +81,7 @@ assert_cc_confs() {
 
 # Checks that cc config files were generated
 assert_checked_in_cc_confs() {
-  assert_file_exists ${DIR}/cc/stub.BUILD
+  assert_file_exists ${DIR}/cc/test.BUILD
   assert_file_not_exists ${DIR}/cc/cc_toolchain_config.bzl
   assert_file_not_exists ${DIR}/cc/dummy_toolchain.bzl
   assert_file_not_exists ${DIR}/cc/cc_wrapper.sh
@@ -89,7 +89,7 @@ assert_checked_in_cc_confs() {
 
 # Checks that cc config files were not generated
 assert_no_cc_confs() {
-  assert_file_not_exists ${DIR}/cc/stub.BUILD
+  assert_file_not_exists ${DIR}/cc/test.BUILD
   assert_file_not_exists ${DIR}/cc/cc_toolchain_config.bzl
   assert_file_not_exists ${DIR}/cc/dummy_toolchain.bzl
   assert_file_not_exists ${DIR}/cc/cc_wrapper.sh

--- a/tests/rbe_repo/rbe_autoconf_checks.sh
+++ b/tests/rbe_repo/rbe_autoconf_checks.sh
@@ -16,6 +16,12 @@
 
 # This bash script defines common assertion functions for rbe_autoconfig
 # file checks.
+# Usage: Use only from an sh_test target.
+# First argument is the location of the empty file in the test
+# directory produced by rbe_autoconfig when create_testdata attr
+# is used.
+# All remaining args are interpreted as calls to functions in this
+# file.
 
 set -e
 

--- a/tests/rbe_repo/rbe_autoconf_checks.sh
+++ b/tests/rbe_repo/rbe_autoconf_checks.sh
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This bash script defines common assertion functions for rbe_autoconfig
+# file checks.
+
 set -e
 
 assert_file_not_exists() {


### PR DESCRIPTION
Basic unit tests that verify the file outputs in the external repo folder for now. Will create more complex unit tests in upcoming PR.
Setting parallelism of analysis phase that runs these tests to 1 as rbe_autoconfig targets cannot run in parallel.

Tests work as follows:
* As part of rbe_autoconfig rule creates (optionally) a copy of all generated artifacts (BUILD files, bzl files, etc). BUILD files are renamed to test.BUILD (to avoid Bazel reading them). Rule also creates a root BUILD file in test copy that has a single filegroup. This enables all tests to refer to these tests artifacts properly.
* Tests then declare dependency on test copy filegroup and can make assertions
* This first PR adds basic tests that verify files are present according to basic attrs of rule (whether checked in or generated configs are used, whether java/cc configs are generated).
* Will be adding additional tests in upcoming PRs
* Note generated config tests are not run in BuildKite CI as it does not support docker yet.