### PR TITLE
Fix GCB CI job so that it can successfully launch RBE builds

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,3 +9,8 @@ steps:
   - --config=remote
   - --remote_instance_name=projects/asci-toolchain/instances/default_instance
   - --noremote_accept_cached
+
+# Specify a custom GCS bucket hosted on the GCP project owned by toolchains
+# team to upload logs.
+logsBucket: "gs://asci-toolchain-gcb-logs-bucket-from-bazel-untrusted"
+


### PR DESCRIPTION
1. Make the GCB job launch RBE builds to the RBE instance on the GCP
   project hosting the GCB job.
2. Upload logs to a bucket owned by toolchains team to ensure toolchains
   team has the ability to set the ACL permissions on the logs.