### PR TITLE
Tests for output_base

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -45,5 +45,3 @@ platforms:
     - "--extra_execution_platforms=@bazel_toolchains//configs/ubuntu16_04_clang/latest:platform_docker"
     - "--host_platform=@bazel_toolchains//configs/ubuntu16_04_clang/latest:platform_docker"
     - "--platforms=@bazel_toolchains//configs/ubuntu16_04_clang/latest:platform_docker"
-    # TODO(nlopezgi): remove this flag once rbe_autoconfig can be run in parallel
-    - "--loading_phase_threads=1"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -273,7 +273,7 @@ rbe_autoconfig(
     create_testdata = True,
     use_checked_in_confs = False,
 )
-  
+
 rbe_autoconfig(
     name = "rbe_autoconf_config_repos_no_cc_config",
     bazel_version = _ubuntu1604_bazel,
@@ -367,10 +367,28 @@ rbe_autoconfig(
 )
 
 rbe_autoconfig(
+    name = "rbe_autoconf_output_base_no_java",
+    bazel_version = _ubuntu1604_bazel,
+    create_java_configs = False,
+    create_testdata = True,
+    output_base = "tests/config/rbe_autoconf_output_base_no_java",
+    use_checked_in_confs = False,
+)
+
+rbe_autoconfig(
+    name = "rbe_autoconf_output_base_no_cc",
+    bazel_version = _ubuntu1604_bazel,
+    create_cc_configs = False,
+    create_testdata = True,
+    output_base = "tests/config/rbe_autoconf_output_base_no_cc",
+    use_checked_in_confs = False,
+)
+
+rbe_autoconfig(
     name = "rbe_autoconf_config_repos_output_base",
     bazel_version = _ubuntu1604_bazel,
     config_repos = [
-        "local_config_sh", 
+        "local_config_sh",
         "bazel_skylib",
     ],
     create_testdata = True,

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -101,7 +101,7 @@ gcs_file(
     sha256 = "5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9",
 )
 
-load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
+load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig", "rbe_autoconfig_root")
 
 rbe_autoconfig(name = "rbe_default")
 
@@ -273,7 +273,7 @@ rbe_autoconfig(
     create_testdata = True,
     use_checked_in_confs = False,
 )
-
+  
 rbe_autoconfig(
     name = "rbe_autoconf_config_repos_no_cc_config",
     bazel_version = _ubuntu1604_bazel,
@@ -357,3 +357,27 @@ rbe_autoconfig(
     repository = "google/bazel",
     tag = "0.23.2",
 )
+
+rbe_autoconfig(
+    name = "rbe_autoconf_output_base",
+    bazel_version = _ubuntu1604_bazel,
+    create_testdata = True,
+    output_base = "tests/config/rbe_autoconf_output_base",
+    use_checked_in_confs = False,
+)
+
+rbe_autoconfig(
+    name = "rbe_autoconf_config_repos_output_base",
+    bazel_version = _ubuntu1604_bazel,
+    config_repos = [
+        "local_config_sh", 
+        "bazel_skylib",
+    ],
+    create_testdata = True,
+    output_base = "tests/config/rbe_autoconf_config_repos_output_base",
+    use_checked_in_confs = False,
+)
+
+# Needed for testing purposes. Creates a file that exposes
+# the value of RBE_AUTOCONF_ROOT
+rbe_autoconfig_root(name = "rbe_autoconfig_root")

--- a/rules/rbe_repo.bzl
+++ b/rules/rbe_repo.bzl
@@ -211,7 +211,7 @@ _RBE_UBUNTU_TARGET_COMPAT_WITH = [
 ]
 _VERBOSE = False
 
-def _impl(ctx):
+def _rbe_autoconfig_impl(ctx):
     """Core implementation of _rbe_autoconfig repository rule."""
 
     bazel_version_debug = "Bazel %s" % ctx.attr.bazel_version
@@ -696,16 +696,7 @@ def _expand_outputs(ctx, bazel_version, project_root):
         # Copy any additional external repos that were requested
         if ctx.attr.config_repos:
             for repo in ctx.attr.config_repos:
-                repo_dest = dest + repo + "/"
-                result = ctx.execute(["mkdir", "-p", repo_dest])
-                _print_exec_results("create %s output dir" % repo, result)
-
-                # Get the files that were created in the repo dir
-                ctx.file(repo + "_config_files.sh", ("echo $(find ./%s -type f | sort -n)" % repo), True)
-                result = ctx.execute(["./" + repo + "_config_files.sh"])
-                _print_exec_results("resolve %s repo files" % repo, result)
-                repo_files = result.stdout.splitlines()[0].split(" ")
-                args = ["cp"] + repo_files + [repo_dest]
+                args = ["rsync", "-aR", "./%s" % repo, dest]
                 result = ctx.execute(args)
                 _print_exec_results("copy %s repo files" % repo, result, True, args)
 
@@ -737,6 +728,13 @@ filegroup(
     # This is needed for tests to reference the location
     # of all test outputs.
     ctx.file("test/empty", "", False)
+
+def rbe_autoconfig_root_impl(ctx):
+    """Core implementation of rbe_autoconfig_root repository rule."""
+    ctx.file("AUTOCONF_ROOT", ctx.os.environ.get(_AUTOCONF_ROOT, None), False)
+    ctx.file("BUILD", """package(default_visibility = ["//visibility:public"])
+exports_files(["AUTOCONF_ROOT"])
+""", False)
 
 # Private declaration of _rbe_autoconfig repository rule. Do not use this
 # rule directly, use rbe_autoconfig macro declared below.
@@ -870,8 +868,18 @@ _rbe_autoconfig = repository_rule(
     environ = [
         _AUTOCONF_ROOT,
     ],
-    implementation = _impl,
+    implementation = _rbe_autoconfig_impl,
+    local=True
 )
+
+# Rule that exposes the location of _AUTOCONF_ROOT for test
+# rules to consume.
+rbe_autoconfig_root = repository_rule(
+    environ = [
+        _AUTOCONF_ROOT,
+    ],
+    implementation=rbe_autoconfig_root_impl,
+    local=True)
 
 def rbe_autoconfig(
         name,

--- a/rules/rbe_repo.bzl
+++ b/rules/rbe_repo.bzl
@@ -869,7 +869,7 @@ _rbe_autoconfig = repository_rule(
         _AUTOCONF_ROOT,
     ],
     implementation = _rbe_autoconfig_impl,
-    local=True
+    local = True,
 )
 
 # Rule that exposes the location of _AUTOCONF_ROOT for test
@@ -878,8 +878,9 @@ rbe_autoconfig_root = repository_rule(
     environ = [
         _AUTOCONF_ROOT,
     ],
-    implementation=rbe_autoconfig_root_impl,
-    local=True)
+    implementation = rbe_autoconfig_root_impl,
+    local = True,
+)
 
 def rbe_autoconfig(
         name,

--- a/tests/rbe_repo/BUILD
+++ b/tests/rbe_repo/BUILD
@@ -447,8 +447,44 @@ sh_test(
     ],
     data = [
         ":rbe_autoconf_checks.sh",
-        "@rbe_autoconfig_root//:AUTOCONF_ROOT",
         "@rbe_autoconf_output_base//test:exported_testdata",
+        "@rbe_autoconfig_root//:AUTOCONF_ROOT",
+    ],
+)
+
+sh_test(
+    name = "rbe_autoconf_output_base_no_java_test",
+    srcs = [":rbe_autoconf_output_base_checks.sh"],
+    args = [
+        "$(location @rbe_autoconfig_root//:AUTOCONF_ROOT)",
+        "tests/config/rbe_autoconf_output_base_no_java",
+        _ubuntu1604_bazel,
+        "assert_output_base_cc_confs",
+        "assert_output_base_no_java_confs",
+        "assert_output_base_platform_confs",
+    ],
+    data = [
+        ":rbe_autoconf_checks.sh",
+        "@rbe_autoconf_output_base_no_java//test:exported_testdata",
+        "@rbe_autoconfig_root//:AUTOCONF_ROOT",
+    ],
+)
+
+sh_test(
+    name = "rbe_autoconf_output_base_no_cc_test",
+    srcs = [":rbe_autoconf_output_base_checks.sh"],
+    args = [
+        "$(location @rbe_autoconfig_root//:AUTOCONF_ROOT)",
+        "tests/config/rbe_autoconf_output_base_no_cc",
+        _ubuntu1604_bazel,
+        "assert_output_base_no_cc_confs",
+        "assert_output_base_java_confs",
+        "assert_output_base_platform_confs",
+    ],
+    data = [
+        ":rbe_autoconf_checks.sh",
+        "@rbe_autoconf_output_base_no_cc//test:exported_testdata",
+        "@rbe_autoconfig_root//:AUTOCONF_ROOT",
     ],
 )
 
@@ -466,15 +502,15 @@ sh_test(
     ],
     data = [
         ":rbe_autoconf_checks.sh",
-        "@rbe_autoconfig_root//:AUTOCONF_ROOT",
         "@rbe_autoconf_config_repos_output_base//test:exported_testdata",
+        "@rbe_autoconfig_root//:AUTOCONF_ROOT",
     ],
 )
 
 file_test(
     name = "rbe_autoconf_config_repos_output_base_run_in_container_test",
     file = "@rbe_autoconf_config_repos_output_base//test:container/run_in_container.sh",
-    regexp = "bazel build @local_config_sh/",
+    regexp = "bazel build @local_config_cc//... @local_config_sh//... @bazel_skylib//...",
 )
 
 file_test(
@@ -488,4 +524,3 @@ file_test(
     file = "@rbe_autoconf_config_repos_output_base//test:bazel_skylib/test.BUILD",
     regexp = "bzl_library.bzl",
 )
-

--- a/tests/rbe_repo/BUILD
+++ b/tests/rbe_repo/BUILD
@@ -20,6 +20,10 @@ load(
     "//configs/ubuntu16_04_clang:versions.bzl",
     RBE_UBUNTU16_04_LATEST = "LATEST",
 )
+load(
+    "//configs/dependency-tracking:ubuntu1604.bzl",
+    _ubuntu1604_bazel = "bazel",
+)
 
 # sh_tests below verify that the rbe_autoconfig targets have the
 # right file structure in the external folder repo
@@ -429,4 +433,59 @@ file_test(
     regexp = "9596a8fbd6a6a77b2fe1272b145235b43f516b4f86eb470d5ee99b738ce37994",
 )
 
-# TODO(nlopezgi): Add tests that verify files were copied to output_folder
+# Tests for output_base. These require RBE_AUTOCONF_ROOT env variable to be set
+sh_test(
+    name = "rbe_autoconf_output_base_test",
+    srcs = [":rbe_autoconf_output_base_checks.sh"],
+    args = [
+        "$(location @rbe_autoconfig_root//:AUTOCONF_ROOT)",
+        "tests/config/rbe_autoconf_output_base",
+        _ubuntu1604_bazel,
+        "assert_output_base_cc_confs",
+        "assert_output_base_java_confs",
+        "assert_output_base_platform_confs",
+    ],
+    data = [
+        ":rbe_autoconf_checks.sh",
+        "@rbe_autoconfig_root//:AUTOCONF_ROOT",
+        "@rbe_autoconf_output_base//test:exported_testdata",
+    ],
+)
+
+sh_test(
+    name = "rbe_autoconf_config_repos_output_base_test",
+    srcs = [":rbe_autoconf_output_base_checks.sh"],
+    args = [
+        "$(location @rbe_autoconfig_root//:AUTOCONF_ROOT)",
+        "tests/config/rbe_autoconf_config_repos_output_base",
+        _ubuntu1604_bazel,
+        "assert_output_base_cc_confs",
+        "assert_output_base_java_confs",
+        "assert_output_base_platform_confs",
+        "assert_output_base_custom_confs",
+    ],
+    data = [
+        ":rbe_autoconf_checks.sh",
+        "@rbe_autoconfig_root//:AUTOCONF_ROOT",
+        "@rbe_autoconf_config_repos_output_base//test:exported_testdata",
+    ],
+)
+
+file_test(
+    name = "rbe_autoconf_config_repos_output_base_run_in_container_test",
+    file = "@rbe_autoconf_config_repos_output_base//test:container/run_in_container.sh",
+    regexp = "bazel build @local_config_sh/",
+)
+
+file_test(
+    name = "rbe_autoconf_config_repos_output_base_sh_toolchain_test",
+    file = "@rbe_autoconf_config_repos_output_base//test:local_config_sh/test.BUILD",
+    regexp = "sh_toolchain",
+)
+
+file_test(
+    name = "rbe_autoconf_config_repos_output_base_skilib_toolchain_test",
+    file = "@rbe_autoconf_config_repos_output_base//test:bazel_skylib/test.BUILD",
+    regexp = "bzl_library.bzl",
+)
+

--- a/tests/rbe_repo/rbe_autoconf_checks.sh
+++ b/tests/rbe_repo/rbe_autoconf_checks.sh
@@ -23,7 +23,7 @@
 # All remaining args are interpreted as calls to functions in this
 # file.
 
-set -e
+set -ex
 
 assert_file_not_exists() {
   FILE=$1
@@ -109,6 +109,46 @@ assert_java_home() {
 # Checks that java_home was not read from container
 assert_no_java_home() {
   assert_file_not_exists ${DIR}/get_java_home.sh
+}
+
+# Checks that cc config files were generated in the output_base
+assert_output_base_cc_confs() {
+  assert_file_exists ${DIR}/cc/BUILD
+  assert_file_exists ${DIR}/cc/cc_toolchain_config.bzl
+  assert_file_exists ${DIR}/cc/dummy_toolchain.bzl
+  assert_file_exists ${DIR}/cc/cc_wrapper.sh
+}
+
+# Checks that cc config files were not generated in the output_base
+assert_output_base_no_cc_confs() {
+  assert_file_not_exists ${DIR}/cc/BUILD
+  assert_file_not_exists ${DIR}/cc/cc_toolchain_config.bzl
+  assert_file_not_exists ${DIR}/cc/dummy_toolchain.bzl
+  assert_file_not_exists ${DIR}/cc/cc_wrapper.sh
+}
+
+# Checks that java config files were generated in the output_base
+assert_output_base_java_confs() {
+  assert_file_exists ${DIR}/java/BUILD
+}
+
+# Checks that java config files were not generated in the output_base
+assert_output_base_no_java_confs() {
+  assert_file_not_exists ${DIR}/java/BUILD
+}
+
+# Checks that platform config files were generated in the output_base
+assert_output_base_platform_confs() {
+  assert_file_exists ${DIR}/config/BUILD
+}
+
+# Checks that files for custom repos (bazel_skylib, local_config_sh) 
+# were generated in the output_base
+assert_output_base_custom_confs() {
+  assert_file_exists ${DIR}/local_config_sh/WORKSPACE
+  assert_file_exists ${DIR}/local_config_sh/BUILD
+  assert_file_exists ${DIR}/bazel_skylib/WORKSPACE
+  assert_file_exists ${DIR}/bazel_skylib/BUILD
 }
 
 EMPTY_FILE=$1

--- a/tests/rbe_repo/rbe_autoconf_checks.sh
+++ b/tests/rbe_repo/rbe_autoconf_checks.sh
@@ -23,7 +23,7 @@
 # All remaining args are interpreted as calls to functions in this
 # file.
 
-set -ex
+set -e
 
 assert_file_not_exists() {
   FILE=$1
@@ -159,4 +159,3 @@ do
     $var
   fi
 done
-

--- a/tests/rbe_repo/rbe_autoconf_output_base_checks.sh
+++ b/tests/rbe_repo/rbe_autoconf_output_base_checks.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This bash script provides an entry point for checks for 
+# rbe_autoconfig that use output_base.
+# It wraps around rbe_autoconf_checks in order
+# to resolve the directory where files are to be checked.
+# Usage: Use only from an sh_test target.
+# First argument is the location of the AUTOCONF_ROOT file which
+# has a single line with the absolute path to the root of the project
+# The second argument is the output_base declared in the rbe_autoconfig
+# rule that is tested.
+# The third argument is the Bazel version
+# All remaining args are interpreted as calls to functions in th
+# rbe_autoconf_checks.
+
+set -ex
+
+AUTOCONF_ROOT=$1
+OUTPUT_BASE=$2
+BAZEL_VERSION=$3
+
+OUTPUT_BASE_EMPTY=$(cat ${AUTOCONF_ROOT})/${OUTPUT_BASE}/bazel_${BAZEL_VERSION}/empty
+set -- ${OUTPUT_BASE_EMPTY} "${@:4}"
+
+source tests/rbe_repo/rbe_autoconf_checks.sh
+
+

--- a/tests/rbe_repo/rbe_autoconf_output_base_checks.sh
+++ b/tests/rbe_repo/rbe_autoconf_output_base_checks.sh
@@ -20,14 +20,14 @@
 # to resolve the directory where files are to be checked.
 # Usage: Use only from an sh_test target.
 # First argument is the location of the AUTOCONF_ROOT file which
-# has a single line with the absolute path to the root of the project
+# has a single line with the absolute path to the root of the project.
 # The second argument is the output_base declared in the rbe_autoconfig
 # rule that is tested.
-# The third argument is the Bazel version
+# The third argument is the Bazel version.
 # All remaining args are interpreted as calls to functions in th
 # rbe_autoconf_checks.
 
-set -ex
+set -e
 
 AUTOCONF_ROOT=$1
 OUTPUT_BASE=$2
@@ -37,5 +37,3 @@ OUTPUT_BASE_EMPTY=$(cat ${AUTOCONF_ROOT})/${OUTPUT_BASE}/bazel_${BAZEL_VERSION}/
 set -- ${OUTPUT_BASE_EMPTY} "${@:4}"
 
 source tests/rbe_repo/rbe_autoconf_checks.sh
-
-


### PR DESCRIPTION
* Created infra to test use of output_base 
  - Created repo rule that exposes value of env variable `RBE_AUTOCONF_ROOT` for tests to be able to access it
  - Created shell script that resolves location of produced files and forwards checks to rbe_autoconf_checks

* Created tests for output_base
  - base case
  - no java configs case
  - no cc configs case
  - extra config repos case