### PR TITLE
improve validations in rbe_autoconfig

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -26,6 +26,7 @@ platforms:
     - "//tests/rbe_repo:rbe_autoconf_base_container_digest_java_alias_test"
     - "//tests/rbe_repo:rbe_autoconf_constraints_exec_compatible_with_test"
     - "//tests/rbe_repo:rbe_autoconf_constraints_target_compatible_with_test"
+    - "//tests/rbe_repo:rbe_autoconf_generate_no_docker_pull_test"
     # TODO(nlopezgi): add tests that require docker binary once supported on
     # BuildKite
     # docker_autoconfig tests

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -391,6 +391,23 @@ rbe_autoconfig(
     use_checked_in_confs = False,
 )
 
+# Test to validate no docker image is pulled when a custom container
+# is used where no cc_configs are needed and java_home is passed
+# explicitly.
+rbe_autoconfig(
+    name = "rbe_autoconf_generate_no_docker_pull",
+    bazel_version = _ubuntu1604_bazel,
+    create_cc_configs = False,
+    create_testdata = True,
+    digest = "sha256:ab88c40463d782acc4289948fe0b1577de0b143a753cea35cac34535203f8ca7",
+    env = clang_env(),
+    java_home = "test-case-java-home",
+    output_base = "tests/config/rbe_autoconf_generate_no_docker_pull",
+    registry = "gcr.io",
+    repository = "asci-toolchain/nosla-ubuntu16_04-bazel-docker-gcloud",
+    use_checked_in_confs = False,
+)
+
 # Needed for testing purposes. Creates a file that exposes
 # the value of RBE_AUTOCONF_ROOT
 rbe_autoconfig_root(name = "rbe_autoconfig_root")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -266,7 +266,6 @@ rbe_autoconfig(
     bazel_version = _ubuntu1604_bazel,
     config_repos = ["local_config_sh"],
     create_testdata = True,
-    use_checked_in_confs = False,
 )
 
 rbe_autoconfig(
@@ -275,7 +274,6 @@ rbe_autoconfig(
     config_repos = ["local_config_sh"],
     create_cc_configs = False,
     create_testdata = True,
-    use_checked_in_confs = False,
 )
 
 rbe_autoconfig(
@@ -388,7 +386,6 @@ rbe_autoconfig(
     ],
     create_testdata = True,
     output_base = "tests/config/rbe_autoconf_config_repos_output_base",
-    use_checked_in_confs = False,
 )
 
 # Test to validate no docker image is pulled when a custom container
@@ -404,7 +401,6 @@ rbe_autoconfig(
     java_home = "test-case-java-home",
     registry = "gcr.io",
     repository = "asci-toolchain/nosla-ubuntu16_04-bazel-docker-gcloud",
-    use_checked_in_confs = False,
 )
 
 # Needed for testing purposes. Creates a file that exposes

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -402,7 +402,6 @@ rbe_autoconfig(
     digest = "sha256:ab88c40463d782acc4289948fe0b1577de0b143a753cea35cac34535203f8ca7",
     env = clang_env(),
     java_home = "test-case-java-home",
-    output_base = "tests/config/rbe_autoconf_generate_no_docker_pull",
     registry = "gcr.io",
     repository = "asci-toolchain/nosla-ubuntu16_04-bazel-docker-gcloud",
     use_checked_in_confs = False,

--- a/rules/rbe_repo.bzl
+++ b/rules/rbe_repo.bzl
@@ -264,7 +264,7 @@ def _rbe_autoconfig_impl(ctx):
 
     # If user picks rbe-ubuntu 16_04 container and
     # a config exists for the current version of Bazel, create aliases and return
-    if ctx.attr.config_version:
+    if ctx.attr.config_version and not config_repos:
         _use_standard_config(ctx)
 
         # Copy all outputs to the test directory
@@ -334,14 +334,14 @@ def _resolve_project_root(ctx):
     # using the env variable
     project_root = None
     use_default_project = None
-    if not ctx.attr.config_version and (ctx.attr.output_base or ctx.attr.config_repos):
+    if (not ctx.attr.config_version and ctx.attr.output_base) or ctx.attr.config_repos:
         project_root = ctx.os.environ.get(_AUTOCONF_ROOT, None)
 
         # TODO (nlopezgi): validate _AUTOCONF_ROOT points to a valid Bazel project
         use_default_project = False
         if not project_root:
             fail(("%s env variable must be set for rbe_autoconfig" +
-                  " to function properly when output_base is set") % _AUTOCONF_ROOT)
+                  " to function properly when output_base or config_repos are set") % _AUTOCONF_ROOT)
     elif not ctx.attr.config_version:
         # TODO(nlopezgi): consider using native.existing_rules() to validate
         # bazel_toolchains repo exists.

--- a/rules/rbe_repo.bzl
+++ b/rules/rbe_repo.bzl
@@ -264,7 +264,7 @@ def _rbe_autoconfig_impl(ctx):
 
     # If user picks rbe-ubuntu 16_04 container and
     # a config exists for the current version of Bazel, create aliases and return
-    if ctx.attr.config_version and not config_repos:
+    if ctx.attr.config_version and not ctx.attr.config_repos:
         _use_standard_config(ctx)
 
         # Copy all outputs to the test directory
@@ -363,7 +363,7 @@ def _resolve_project_root(ctx):
 def _pull_container_needed(ctx):
     if ctx.attr.tag:
         return True
-    if ctx.attr.config_version:
+    if ctx.attr.config_version and not ctx.attr.config_repos:
         return False
     if not ctx.attr.create_cc_configs and ctx.attr.java_home and not ctx.attr.config_repos:
         return False
@@ -438,7 +438,8 @@ def _pull_image(ctx, docker_tool_path, image_name):
 
     # Create a dummy file with the image name to enable testing
     # if container was pulled
-    ctx.file("image_name", image_name, False)
+    ctx.file("image_name", """# Test file created to signal container was pulled
+%s""" % image_name, False)
 
 # Gets the value of java_home either from attr or
 # by running docker run image_name printenv JAVA_HOME.

--- a/tests/rbe_repo/BUILD
+++ b/tests/rbe_repo/BUILD
@@ -86,6 +86,7 @@ sh_test(
         "assert_cc_confs",
         "assert_java_confs",
         "assert_java_home",
+        "assert_image_pulled",
     ],
     data = [
         "@rbe_autoconf_generate//test:empty",
@@ -523,4 +524,28 @@ file_test(
     name = "rbe_autoconf_config_repos_output_base_skilib_toolchain_test",
     file = "@rbe_autoconf_config_repos_output_base//test:bazel_skylib/test.BUILD",
     regexp = "bzl_library.bzl",
+)
+
+# tests to validate docker image was / was not pulled
+sh_test(
+    name = "rbe_autoconf_generate_no_docker_pull_test",
+    srcs = [":rbe_autoconf_checks.sh"],
+    args = [
+        "$(location @rbe_autoconf_generate_no_docker_pull//test:empty)",
+        "assert_basic_cofig",
+        "assert_checked_in_confs",
+        "assert_java_confs",
+        "assert_no_java_home",
+        "assert_image_not_pulled",
+    ],
+    data = [
+        "@rbe_autoconf_generate_no_docker_pull//test:empty",
+        "@rbe_autoconf_generate_no_docker_pull//test:exported_testdata",
+    ],
+)
+
+file_test(
+    name = "rbe_autoconf_generate_image_name_test",
+    file = "@rbe_autoconf_generate//test:image_name",
+    regexp = RBE_UBUNTU16_04_LATEST,
 )

--- a/tests/rbe_repo/rbe_autoconf_checks.sh
+++ b/tests/rbe_repo/rbe_autoconf_checks.sh
@@ -67,6 +67,16 @@ assert_no_checked_in_confs() {
   assert_file_exists ${DIR}/container/run_in_container.sh
 }
 
+# Checks the dummy file produced after image is pulled is present
+assert_image_pulled() {
+  assert_file_exists ${DIR}/image_name
+}
+
+# Checks the dummy file produced after image is pulled is not present
+assert_image_not_pulled() {
+  assert_file_not_exists ${DIR}/image_name
+}
+
 # Checks that java config files were generated
 assert_java_confs() {
   assert_file_exists ${DIR}/java/test.BUILD


### PR DESCRIPTION
* Add validations to check when docker image will be needed to be pulled
* Split off logic to resolve project_root from main impl method
* Produce a dummy file if an image was pulled (for tests)
* Add tests that validate an image will not be pulled in edge case
* Add tests to valiate image was pulled in other cases