### PR TITLE
Fix issues with rbe_autoconfig

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -105,7 +105,8 @@ load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig", "rbe_autoconfig_
 
 rbe_autoconfig(
     name = "rbe_default",
-    use_checked_in_confs = "Force",
+    # TODO(ngiraldo) reenable use_checked_in_confs after 0.25.0 configs are released
+    #use_checked_in_confs = "Force",
 )
 
 # Targets used by automatic config generation and release service.

--- a/rules/rbe_repo.bzl
+++ b/rules/rbe_repo.bzl
@@ -1104,10 +1104,10 @@ def rbe_autoconfig(
     )
 
     if use_checked_in_confs == _CHECKED_IN_CONFS_FORCE and not config_version:
-        fail("use_checked_in_confs was set to \"%s\" but no checked-in configs " +
+        fail(("use_checked_in_confs was set to \"%s\" but no checked-in configs " +
              "were found. Please check your pin to bazel-toolchains is up " +
              "to date, and that you are using a release version of " +
-             "Bazel." % _CHECKED_IN_CONFS_FORCE)
+             "Bazel.") % _CHECKED_IN_CONFS_FORCE)
 
     _rbe_autoconfig(
         name = name,

--- a/rules/rbe_repo.bzl
+++ b/rules/rbe_repo.bzl
@@ -770,6 +770,10 @@ def _expand_outputs(ctx, bazel_version, project_root):
                 result = ctx.execute(args)
                 _print_exec_results("Remove %s repo files from repo dir" % repo, result, True, args)
 
+        # TODO(ngiraldo): Generate new BUILD files that point to checked in configs
+        # Create an empty BUILD file so the repo can be built
+        ctx.file("BUILD", "", False)
+
 # Copies all contents of the external repo to a test directory,
 # modifies name of all BUILD files (to enable file_test to operate on them), and
 # creates a root BUILD file in test directory with a filegroup that contains
@@ -1105,9 +1109,9 @@ def rbe_autoconfig(
 
     if use_checked_in_confs == _CHECKED_IN_CONFS_FORCE and not config_version:
         fail(("use_checked_in_confs was set to \"%s\" but no checked-in configs " +
-             "were found. Please check your pin to bazel-toolchains is up " +
-             "to date, and that you are using a release version of " +
-             "Bazel.") % _CHECKED_IN_CONFS_FORCE)
+              "were found. Please check your pin to bazel-toolchains is up " +
+              "to date, and that you are using a release version of " +
+              "Bazel.") % _CHECKED_IN_CONFS_FORCE)
 
     _rbe_autoconfig(
         name = name,


### PR DESCRIPTION
* Fail message formatting was resulting in error
* create an empty build file in rbe_autoconf repos that have output_base so that its possible to build these.