### PR TITLE
Turn on updating to unstable releases in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "ignoreUnstable": false
 }


### PR DESCRIPTION
This option is needed to support updates of the style: https://semver.org/#spec-item-9 as per the conversation on https://github.com/renovatebot/renovate/issues/3645