### PR TITLE
update skylib and fix issue with test depending on skylib

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -386,7 +386,6 @@ rbe_autoconfig(
     bazel_version = _ubuntu1604_bazel,
     config_repos = [
         "local_config_sh",
-        "bazel_skylib",
     ],
     create_testdata = True,
     output_base = "tests/config/rbe_autoconf_config_repos_output_base",

--- a/repositories/repositories.bzl
+++ b/repositories/repositories.bzl
@@ -73,9 +73,9 @@ def repositories():
     if "bazel_skylib" not in excludes:
         http_archive(
             name = "bazel_skylib",
-            sha256 = "eb5c57e4c12e68c0c20bc774bfbc60a568e800d025557bc4ea022c6479acc867",
-            strip_prefix = "bazel-skylib-0.6.0",
-            urls = ["https://github.com/bazelbuild/bazel-skylib/archive/0.6.0.tar.gz"],
+            sha256 = "2ea8a5ed2b448baf4a6855d3ce049c4c452a6470b1efd1504fdb7c1c134d220a",
+            strip_prefix = "bazel-skylib-0.8.0",
+            urls = ["https://github.com/bazelbuild/bazel-skylib/archive/0.8.0.tar.gz"],
         )
 
     # ================================ GPG Keys ================================

--- a/tests/rbe_repo/BUILD
+++ b/tests/rbe_repo/BUILD
@@ -511,7 +511,7 @@ sh_test(
 file_test(
     name = "rbe_autoconf_config_repos_output_base_run_in_container_test",
     file = "@rbe_autoconf_config_repos_output_base//test:container/run_in_container.sh",
-    regexp = "bazel build @local_config_cc//... @local_config_sh//... @bazel_skylib//...",
+    regexp = "bazel build @local_config_cc//... @local_config_sh//...",
 )
 
 # tests to validate docker image was / was not pulled

--- a/tests/rbe_repo/rbe_autoconf_checks.sh
+++ b/tests/rbe_repo/rbe_autoconf_checks.sh
@@ -158,8 +158,6 @@ assert_output_base_platform_confs() {
 assert_output_base_custom_confs() {
   assert_file_exists ${DIR}/local_config_sh/WORKSPACE
   assert_file_exists ${DIR}/local_config_sh/BUILD
-  assert_file_exists ${DIR}/bazel_skylib/WORKSPACE
-  assert_file_exists ${DIR}/bazel_skylib/BUILD
 }
 
 EMPTY_FILE=$1


### PR DESCRIPTION
I had created a test depending on building @bazel_skylib, which is not really a good idea to begin with. Latest skylib update breaks the test. Removing that dependency. I really like how our bots updating deps makes it easier to catch these issues early.

replaces https://github.com/bazelbuild/bazel-toolchains/pull/494