### PR TITLE
enabling building bazel from source for docker_toolchain_autoconfig

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -36,6 +36,7 @@ platforms:
     - "//tests/config:ubuntu16_04_clang_autoconfig_test"
     - "//tests/config:external-repo-autoconfig_test"
     - "//tests/config:this-project-repo-autoconfig"
+    - "//tests/config:ubuntu-xenial-build-bazel-src"
     - "//configs/ubuntu16_04_clang:default-ubuntu16_04-clang-1.1-bazel_0.18.0-autoconfig_test"
     - "//configs/ubuntu16_04_clang:msan-ubuntu16_04-clang-1.1-bazel_0.18.0-autoconfig_test"
     test_flags:

--- a/rules/BUILD
+++ b/rules/BUILD
@@ -29,6 +29,7 @@ filegroup(
     srcs = [
         "install_bazel_head.sh",
         "install_bazel_version.sh",
+        "build_bazel_version.sh",
     ],
 )
 

--- a/rules/BUILD
+++ b/rules/BUILD
@@ -27,9 +27,9 @@ exports_files([
 filegroup(
     name = "bazel_installers",
     srcs = [
+        "build_bazel_version.sh",
         "install_bazel_head.sh",
         "install_bazel_version.sh",
-        "build_bazel_version.sh",
     ],
 )
 

--- a/rules/build_bazel_version.sh
+++ b/rules/build_bazel_version.sh
@@ -1,0 +1,33 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/env bash
+# Obtains from given URL the Bazel release source dist, and build Bazel.
+# Script requires wget
+# Bazel installation requires gcc, g++, jdk, python, zip / unzip
+# $1: bazel_url
+set -e
+echo === Building from source a Bazel release version ===
+
+bazel_url=$1
+
+mkdir -p /src/bazel
+cd /src/bazel/
+# Use -ca-certificate flag to explicitly tell wget where to look for certs.
+wget $bazel_url --no-verbose --ca-certificate=/etc/ssl/certs/ca-certificates.crt -O /tmp/bazel-src.zip
+mkdir -p /src/bazel/
+unzip /tmp/bazel-src.zip -d /src/bazel/
+cd /src/bazel && env EXTRA_BAZEL_ARGS="--host_javabase=@local_jdk//:jdk" bash ./compile.sh
+mv /src/bazel/output/bazel /usr/local/bin/
+rm -drf /tmp/bazel-src.zip /src/bazel

--- a/tests/config/BUILD
+++ b/tests/config/BUILD
@@ -27,6 +27,8 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
+bazel_latest_with_rc = "0.25.0"
+
 bazel_rc = "1"
 
 docker_toolchain_autoconfig(
@@ -81,7 +83,7 @@ docker_toolchain_autoconfig(
     name = "ubuntu-xenial-custom-bazel-rc-version-autoconfig",
     base = "//tests/container:rbe-test-xenial-with-pkgs.tar",
     bazel_rc_version = bazel_rc,
-    bazel_version = _latest_bazel,
+    bazel_version = bazel_latest_with_rc,
     env = gcc_env(),
     tags = ["manual"],
     test = True,

--- a/tests/config/BUILD
+++ b/tests/config/BUILD
@@ -21,14 +21,13 @@ load(
     "ubuntu16_04_clang_default_packages",
     "ubuntu16_04_clang_default_repos",
 )
+load("//configs/dependency-tracking:ubuntu1604.bzl", _latest_bazel = "bazel")
 
 licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
-bazel_next_release = "0.20.0"
-
-bazel_next_release_rc = "3"
+bazel_rc = "1"
 
 docker_toolchain_autoconfig(
     name = "ubuntu-xenial-autoconfig",
@@ -81,8 +80,18 @@ docker_toolchain_autoconfig(
 docker_toolchain_autoconfig(
     name = "ubuntu-xenial-custom-bazel-rc-version-autoconfig",
     base = "//tests/container:rbe-test-xenial-with-pkgs.tar",
-    bazel_rc_version = bazel_next_release_rc,
-    bazel_version = bazel_next_release,
+    bazel_rc_version = bazel_rc,
+    bazel_version = _latest_bazel,
+    env = gcc_env(),
+    tags = ["manual"],
+    test = True,
+)
+
+docker_toolchain_autoconfig(
+    name = "ubuntu-xenial-build-bazel-src",
+    base = "//tests/container:rbe-test-no-bazel.tar",
+    bazel_version = _latest_bazel,
+    build_bazel_src = True,
     env = gcc_env(),
     tags = ["manual"],
     test = True,

--- a/tests/container/BUILD
+++ b/tests/container/BUILD
@@ -46,6 +46,22 @@ toolchain_container(
     ],
 )
 
+toolchain_container(
+    name = "rbe-test-no-bazel",
+    base = "@official_xenial//image",
+    packages = [
+        "curl",
+        "gcc",
+        "git",
+        "g++",
+        "openjdk-8-jdk",
+        "python-dev",
+        "unzip",
+        "wget",
+        "zip",
+    ],
+)
+
 container_test(
     name = "test-rbe-test-xenial-with-pkgs",
     configs = [

--- a/tests/container/BUILD
+++ b/tests/container/BUILD
@@ -51,9 +51,9 @@ toolchain_container(
     base = "@official_xenial//image",
     packages = [
         "curl",
+        "g++",
         "gcc",
         "git",
-        "g++",
         "openjdk-8-jdk",
         "python-dev",
         "unzip",


### PR DESCRIPTION
Certain OSS cannot use precompiled version of Bazel, so enable building from source using dist release. Only supports release versions, no rc's.