### PR TITLE
Add clang 8.0.0 libraries to the cxx_builtin_include list

### DIFF
--- a/configs/ubuntu16_04_clang/1.2/bazel_0.25.0/default/cc_toolchain_config.bzl
+++ b/configs/ubuntu16_04_clang/1.2/bazel_0.25.0/default/cc_toolchain_config.bzl
@@ -93,6 +93,7 @@ def _windows_msvc_impl(ctx):
 
     cxx_builtin_include_directories = [
         "/usr/local/include",
+        "/usr/local/lib/clang/8.0.0/include",
         "/usr/local/lib/clang/9.0.0/include",
         "/usr/include/x86_64-linux-gnu",
         "/usr/include",
@@ -1375,6 +1376,7 @@ def _impl(ctx):
 
     cxx_builtin_include_directories = [
         "/usr/local/include",
+        "/usr/local/lib/clang/8.0.0/include",
         "/usr/local/lib/clang/9.0.0/include",
         "/usr/include/x86_64-linux-gnu",
         "/usr/include",


### PR DESCRIPTION
When building using Bazel 0.25.x and toolchain 0.25.0, I get
the following errors:

    ERROR: /home/pedro/.cache/bazel/_bazel_pedro/eb366111355e69c7afe372aacd5d95ad/external/com_github_google_benchmark/BUILD.bazel:11:1: undeclared inclusion(s) in rule '@com_github_google_benchmark//:benchmark':
    this rule is missing dependency declarations for the following files included by 'external/com_github_google_benchmark/src/console_reporter.cc':
      '/usr/local/lib/clang/8.0.0/include/stdint.h'
      '/usr/local/lib/clang/8.0.0/include/stddef.h'
      '/usr/local/lib/clang/8.0.0/include/stdarg.h'
      '/usr/local/lib/clang/8.0.0/include/x86intrin.h'
      '/usr/local/lib/clang/8.0.0/include/ia32intrin.h'
      '/usr/local/lib/clang/8.0.0/include/immintrin.h'
      ...

Adding this folder to the list, fixes the issue