### PR TITLE
adding basic external repo example

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,20 +3,21 @@ steps:
 # configs.
 - name: 'l.gcr.io/google/bazel'
   args:
-  - --bazelrc=bazelrc/.bazelrc
+  - --bazelrc=../../../../bazelrc/.bazelrc
   - test
-  - //examples/remotebuildexecution/hello_world/cc:say_hello_test
+  - //:say_hello_test
   - --config=remote
   - --remote_instance_name=projects/asci-toolchain/instances/default_instance
-  - --noremote_accept_cached
+  dir: 'tests/rbe_repo/examples/bazel_toolchains_client'
 
 # Launch a RBE hello world build + unit test using the manually produced
 # configs for Bazel 0.25.0
 - name: 'l.gcr.io/google/bazel'
   args:
-  - --bazelrc=bazelrc/bazel-0.25.0.bazelrc
+  - --bazelrc=../../../../bazelrc/bazel-0.25.0.bazelrc
   - test
-  - //examples/remotebuildexecution/hello_world/cc:say_hello_test
+  - //:say_hello_test
   - --config=remote
   - --remote_instance_name=projects/asci-toolchain/instances/default_instance
   - --noremote_accept_cached
+  dir: 'tests/rbe_repo/examples/bazel_toolchains_client'

--- a/tests/rbe_repo/examples/bazel_toolchains_client/BUILD
+++ b/tests/rbe_repo/examples/bazel_toolchains_client/BUILD
@@ -1,0 +1,34 @@
+# Copyright 2016 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "say_hello",
+    srcs = ["say_hello.cc"],
+    hdrs = ["say_hello.h"],
+)
+
+cc_binary(
+    name = "hello_world",
+    srcs = ["hello_world.cc"],
+    deps = [":say_hello"],
+)
+
+cc_test(
+    name = "say_hello_test",
+    size = "small",
+    srcs = ["say_hello_test.cc"],
+    deps = [":say_hello"],
+)

--- a/tests/rbe_repo/examples/bazel_toolchains_client/WORKSPACE
+++ b/tests/rbe_repo/examples/bazel_toolchains_client/WORKSPACE
@@ -1,0 +1,27 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+workspace(name = "bazel_toolchains_client")
+
+local_repository(
+    name = "bazel_toolchains",
+    path = "../../../..",
+)
+
+load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
+
+rbe_autoconfig(
+    name = "rbe_default",
+    use_checked_in_confs = "Force",
+)

--- a/tests/rbe_repo/examples/bazel_toolchains_client/hello_world.cc
+++ b/tests/rbe_repo/examples/bazel_toolchains_client/hello_world.cc
@@ -1,0 +1,22 @@
+// Copyright 2016 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "say_hello.h"
+
+#include <iostream>
+
+int main(int argc, char** argv) {
+  std::cout << sayHello("world") << std::endl;
+  return 0;
+}

--- a/tests/rbe_repo/examples/bazel_toolchains_client/say_hello.cc
+++ b/tests/rbe_repo/examples/bazel_toolchains_client/say_hello.cc
@@ -1,0 +1,19 @@
+// Copyright 2016 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+
+std::string sayHello(std::string name) {
+  return "Hello, " + name;
+}

--- a/tests/rbe_repo/examples/bazel_toolchains_client/say_hello.h
+++ b/tests/rbe_repo/examples/bazel_toolchains_client/say_hello.h
@@ -1,0 +1,17 @@
+// Copyright 2016 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+
+std::string sayHello(std::string name);

--- a/tests/rbe_repo/examples/bazel_toolchains_client/say_hello_test.cc
+++ b/tests/rbe_repo/examples/bazel_toolchains_client/say_hello_test.cc
@@ -1,0 +1,28 @@
+// Copyright 2016 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "say_hello.h"
+
+#include <iostream>
+#include <string>
+
+int main(int argc, char** argv) {
+  std::string res = sayHello("user");
+  std::string expect = "Hello, user";
+  if (res != expect) {
+    std::cout << "Want '" << expect << "', got '" << res << "'" << std::endl;
+    return 1;
+  }
+  return 0;
+}


### PR DESCRIPTION
Move basic test that runs GCB + RBE to use sources from an external repo that points to bazel-toolchains, not from bazel-toolchains itself.

This PR is duplicating the cc code from https://github.com/bazelbuild/bazel-toolchains/tree/master/examples/remotebuildexecution/hello_world/cc (but that code is used by other tests currently so cannot remove it, and we want this to be a standalone example)