### PR TITLE
make bazel_test_cloudbuild.yaml more generic

### DIFF
--- a/bazel_tests_cloudbuild.yaml
+++ b/bazel_tests_cloudbuild.yaml
@@ -12,32 +12,12 @@
 # for which a toolchain config was published for the given bazel version.
 
 steps:
-# Test that runs with _BAZEL_VERSION and uses checked-in configs
-# directly w/o using rbe_autoconfig. This one runs w/o remote caching.
-# Configs must exist in this repo for the _CONTAINER_MAJOR_VERSION used
-# for this test to pass.
-- name: 'l.gcr.io/google/bazel:${_BAZEL_VERSION}'
-  args:
-  - --bazelrc=bazelrc/.bazelrc.notoolchain
-  - test
-  - //examples/remotebuildexecution/hello_world/cc:say_hello_test
-  - --config=remote
-  - --host_javabase=//configs/ubuntu16_04_clang/${_CONTAINER_MAJOR_VERSION}/bazel_${_BAZEL_VERSION}/java:jdk
-  - --javabase=//configs/ubuntu16_04_clang/${_CONTAINER_MAJOR_VERSION}/bazel_${_BAZEL_VERSION}/java:jdk
-  - --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-  - --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-  - --crosstool_top=//configs/ubuntu16_04_clang/${_CONTAINER_MAJOR_VERSION}/bazel_${_BAZEL_VERSION}/cc:toolchain
-  - --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-  - --extra_toolchains=//configs/ubuntu16_04_clang/${_CONTAINER_MAJOR_VERSION}/bazel_${_BAZEL_VERSION}/config:cc-toolchain
-  - --extra_execution_platforms=//configs/ubuntu16_04_clang/${_CONTAINER_MAJOR_VERSION}/bazel_${_BAZEL_VERSION}/config:platform
-  - --host_platform=//configs/ubuntu16_04_clang/${_CONTAINER_MAJOR_VERSION}/bazel_${_BAZEL_VERSION}/config:platform
-  - --platforms=//configs/ubuntu16_04_clang/${_CONTAINER_MAJOR_VERSION}/bazel_${_BAZEL_VERSION}/config:platform
-  - --remote_instance_name=projects/asci-toolchain/instances/default_instance
-
 # Test that runs with rbe_autoconfig with Bazel ${_BAZEL_VERSION}
+# This test can only run with Bazel versions that have x.x.0 format
+# as we only maintain bazelrc files for these.
 - name: 'l.gcr.io/google/bazel:${_BAZEL_VERSION}'
   args:
-  - --bazelrc=bazelrc/.bazelrc
+  - --bazelrc=bazelrc/bazel-${_BAZEL_VERSION}.bazelrc
   - test
   - //examples/remotebuildexecution/hello_world/cc:say_hello_test
   - --config=remote

--- a/tests/rbe_repo/bazel_legacy_configs.yaml
+++ b/tests/rbe_repo/bazel_legacy_configs.yaml
@@ -1,0 +1,35 @@
+# Steps in this file use toolchain configs produced by rbe_default
+# target with multiple versions of Bazel.
+# Their purpose is to verify the checked in configs are usable on RBE
+# with several older versions of Bazel
+
+# Proper functioning of these test requires the _BAZEL_VERSION and
+# _CONTAINER_MAJOR_VERSION substitution parameters to be set in the trigger
+# with name "config: /bazel_tests_cloudbuild.yaml {_BAZEL_VERSION}"
+# in https://pantheon.corp.google.com/cloud-build/triggers?project=asci-toolchain.
+# _BAZEL_VERSION should point to a version of Bazel to verify with these tests
+# _CONTAINER_MAJOR_VERSION must correspond to a valid container major version
+# for which a toolchain config was published for the given bazel version.
+
+steps:
+# Test that runs with _BAZEL_VERSION and uses checked-in configs
+# directly w/o using rbe_autoconfig. This one runs w/o remote caching.
+# Configs must exist in this repo for the _CONTAINER_MAJOR_VERSION used
+# for this test to pass.
+- name: 'l.gcr.io/google/bazel:${_BAZEL_VERSION}'
+  args:
+  - --bazelrc=bazelrc/.bazelrc.notoolchain
+  - test
+  - //examples/remotebuildexecution/hello_world/cc:say_hello_test
+  - --config=remote
+  - --host_javabase=//configs/ubuntu16_04_clang/${_CONTAINER_MAJOR_VERSION}/bazel_${_BAZEL_VERSION}/java:jdk
+  - --javabase=//configs/ubuntu16_04_clang/${_CONTAINER_MAJOR_VERSION}/bazel_${_BAZEL_VERSION}/java:jdk
+  - --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+  - --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+  - --crosstool_top=//configs/ubuntu16_04_clang/${_CONTAINER_MAJOR_VERSION}/bazel_${_BAZEL_VERSION}/cc:toolchain
+  - --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+  - --extra_toolchains=//configs/ubuntu16_04_clang/${_CONTAINER_MAJOR_VERSION}/bazel_${_BAZEL_VERSION}/config:cc-toolchain
+  - --extra_execution_platforms=//configs/ubuntu16_04_clang/${_CONTAINER_MAJOR_VERSION}/bazel_${_BAZEL_VERSION}/config:platform
+  - --host_platform=//configs/ubuntu16_04_clang/${_CONTAINER_MAJOR_VERSION}/bazel_${_BAZEL_VERSION}/config:platform
+  - --platforms=//configs/ubuntu16_04_clang/${_CONTAINER_MAJOR_VERSION}/bazel_${_BAZEL_VERSION}/config:platform
+  - --remote_instance_name=projects/asci-toolchain/instances/default_instance


### PR DESCRIPTION
* move tests that verify old configs to bazel_legacy_configs.yaml
* make it so that bazel_test_cloudbuild.yaml can work to test both
legacy rcs as well as recent ones.

* Note I'm making changes to triggers that will make other PRs possibly fail. Will try to get this merged asap
