### PR TITLE
cleanups split off from large PR

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,3 @@
+# Disable targets that are part of an embedded bazel project as buildkite
+# only recognizes a single top level WORKSPACE file.
+tests/rbe_repo/examples

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,7 +13,7 @@
 # limitations under the License.
 workspace(name = "bazel_toolchains")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 load(
     "//repositories:repositories.bzl",
     bazel_toolchains_repositories = "repositories",
@@ -359,7 +359,7 @@ rbe_autoconfig(
     name = "rbe_autoconf_output_base",
     bazel_version = _ubuntu1604_bazel,
     create_testdata = True,
-    output_base = "tests/config/rbe_autoconf_output_base",
+    output_base = "bazel-rbe-tests/config/rbe_autoconf_output_base",
     use_checked_in_confs = "False",
 )
 
@@ -368,7 +368,7 @@ rbe_autoconfig(
     bazel_version = _ubuntu1604_bazel,
     create_java_configs = False,
     create_testdata = True,
-    output_base = "tests/config/rbe_autoconf_output_base_no_java",
+    output_base = "bazel-rbe-tests/config/rbe_autoconf_output_base_no_java",
     use_checked_in_confs = "False",
 )
 
@@ -377,7 +377,7 @@ rbe_autoconfig(
     bazel_version = _ubuntu1604_bazel,
     create_cc_configs = False,
     create_testdata = True,
-    output_base = "tests/config/rbe_autoconf_output_base_no_cc",
+    output_base = "bazel-rbe-tests/config/rbe_autoconf_output_base_no_cc",
     use_checked_in_confs = "False",
 )
 
@@ -388,7 +388,7 @@ rbe_autoconfig(
         "local_config_sh",
     ],
     create_testdata = True,
-    output_base = "tests/config/rbe_autoconf_config_repos_output_base",
+    output_base = "bazel-rbe-tests/config/rbe_autoconf_config_repos_output_base",
 )
 
 rbe_autoconfig(
@@ -396,7 +396,7 @@ rbe_autoconfig(
     bazel_version = _ubuntu1604_bazel,
     config_dir = "test_config_dir",
     create_testdata = True,
-    output_base = "tests/config/rbe_autoconf_output_base",
+    output_base = "bazel-rbe-tests/config/rbe_autoconf_output_base",
     use_checked_in_confs = "False",
 )
 
@@ -420,11 +420,3 @@ load("//rules/rbe_repo:util.bzl", "rbe_autoconfig_root")
 # Needed for testing purposes. Creates a file that exposes
 # the value of RBE_AUTOCONF_ROOT
 rbe_autoconfig_root(name = "rbe_autoconfig_root")
-
-# Experiment with tags to see if renovate updates them correctly.
-# TODO (suvanjan): Remove this after experimentation is complete.
-http_archive(
-    name = "renovate_src",
-    sha256 = "3e9c7dcc3ab602dde9656d7ce1c8969f56dd1480b881f272d5d6ad8a713bddcc",
-    url = "https://github.com/smukherj1/renovate-src/archive/0.24.1-1.tar.gz",
-)

--- a/rules/BUILD
+++ b/rules/BUILD
@@ -72,3 +72,13 @@ bzl_library(
         "@io_bazel_rules_docker//container",
     ],
 )
+
+bzl_library(
+    name = "rbe_repo",
+    srcs = [
+        "rbe_repo.bzl",
+    ],
+    deps = [
+        "@bazel_toolchains//rules/rbe_repo",
+    ],
+)

--- a/rules/container/BUILD
+++ b/rules/container/BUILD
@@ -16,6 +16,8 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 licenses(["notice"])  # Apache 2.0
 
+package(default_visibility = ["//visibility:public"])
+
 bzl_library(
     name = "debian_pkg_tar",
     srcs = [

--- a/rules/rbe_repo/BUILD
+++ b/rules/rbe_repo/BUILD
@@ -11,3 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+licenses(["notice"])  # Apache 2.0
+
+package(default_visibility = ["//visibility:public"])
+
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "rbe_repo",
+    srcs = [
+        "build_gen.bzl",
+        "checked_in.bzl",
+        "container.bzl",
+        "outputs.bzl",
+        "toolchain_config_suite_spec.bzl",
+        "util.bzl",
+        "version_check.bzl",
+    ],
+)

--- a/rules/rbe_repo/container.bzl
+++ b/rules/rbe_repo/container.bzl
@@ -116,7 +116,6 @@ def _create_docker_cmd(
     ]
     ctx.file("container/run_in_container.sh", "\n".join(docker_cmd), True)
 
-# Verifies if we need to pull a container to resolve the configs.
 def pull_container_needed(ctx):
     """Returns whether or not pulling a container is needed.
 
@@ -155,8 +154,8 @@ def pull_image(ctx, docker_tool_path, image_name):
 def get_java_home(ctx, docker_tool_path, image_name):
     """Gets the value of java_home.
 
-      Gets the value of java_home either from attr or
-      by running docker run image_name printenv JAVA_HOME.
+    Gets the value of java_home either from attr or
+    by running docker run image_name printenv JAVA_HOME.
 
     Args:
       ctx: the Bazel context object.
@@ -191,8 +190,6 @@ def get_java_home(ctx, docker_tool_path, image_name):
              "create_java_configs is set to True")
     return java_home
 
-# Runs the container (creates command to run inside container) and extracts the
-# toolchain configs.
 def run_and_extract(
         ctx,
         bazel_version,
@@ -204,8 +201,8 @@ def run_and_extract(
         use_default_project):
     """Runs the container and extracts the toolchain configs.
 
-       Runs the container (creates command to run inside container) and extracts the
-       toolchain configs.
+    Runs the container (creates command to run inside container) and extracts the
+    toolchain configs.
 
     Args:
         ctx: the Bazel context object.
@@ -217,7 +214,8 @@ def run_and_extract(
           local_config_cc
       docker_tool_path: path to the docker binary.
       image_name: name of the image to pull.
-      project_root: the absolute path to the root of the project
+      project_root: the absolute path to the root of the project that will
+          be mounted/copied to the container
       use_default_project: whether or not to use the default project to generate configs
     """
     outputs_tar = ctx.attr.name + "_out.tar"
@@ -244,10 +242,10 @@ def run_and_extract(
     clean_data_volume_cmd = ""
     if ctx.attr.copy_resources:
         copy_data_cmd.append("data_volume=$(docker create -v " + _ROOT_DIR + " " + image_name + ")")
-        copy_data_cmd.append("docker cp $(realpath " + project_root + ") $data_volume:" + _REPO_DIR)
-        copy_data_cmd.append("docker cp " + str(ctx.path("container")) + " $data_volume:" + _ROOT_DIR + "/container")
+        copy_data_cmd.append(docker_tool_path + " cp $(realpath " + project_root + ") $data_volume:" + _REPO_DIR)
+        copy_data_cmd.append(docker_tool_path + " cp " + str(ctx.path("container")) + " $data_volume:" + _ROOT_DIR + "/container")
         docker_run_flags += ["--volumes-from", "$data_volume"]
-        clean_data_volume_cmd = "docker rm $data_volume"
+        clean_data_volume_cmd = docker_tool_path + " rm $data_volume"
     else:
         mount_read_only_flag = ":ro"
         if use_default_project:

--- a/rules/rbe_repo/version_check.bzl
+++ b/rules/rbe_repo/version_check.bzl
@@ -1,3 +1,16 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """ Helpers to parse and check version of bazel."""
 
 def extract_version_number(bazel_version_fallback):

--- a/tests/rbe_repo/BUILD
+++ b/tests/rbe_repo/BUILD
@@ -445,7 +445,7 @@ sh_test(
     srcs = [":rbe_autoconf_output_base_checks.sh"],
     args = [
         "$(location @rbe_autoconfig_root//:AUTOCONF_ROOT)",
-        "tests/config/rbe_autoconf_output_base",
+        "bazel-rbe-tests/config/rbe_autoconf_output_base",
         _ubuntu1604_bazel,
         "assert_output_base_cc_confs",
         "assert_output_base_java_confs",
@@ -463,7 +463,7 @@ sh_test(
     srcs = [":rbe_autoconf_output_base_checks.sh"],
     args = [
         "$(location @rbe_autoconfig_root//:AUTOCONF_ROOT)",
-        "tests/config/rbe_autoconf_output_base_no_java",
+        "bazel-rbe-tests/config/rbe_autoconf_output_base_no_java",
         _ubuntu1604_bazel,
         "assert_output_base_cc_confs",
         "assert_output_base_no_java_confs",
@@ -481,7 +481,7 @@ sh_test(
     srcs = [":rbe_autoconf_output_base_checks.sh"],
     args = [
         "$(location @rbe_autoconfig_root//:AUTOCONF_ROOT)",
-        "tests/config/rbe_autoconf_output_base_no_cc",
+        "bazel-rbe-tests/config/rbe_autoconf_output_base_no_cc",
         _ubuntu1604_bazel,
         "assert_output_base_no_cc_confs",
         "assert_output_base_java_confs",
@@ -499,7 +499,7 @@ sh_test(
     srcs = [":rbe_autoconf_output_base_checks.sh"],
     args = [
         "$(location @rbe_autoconfig_root//:AUTOCONF_ROOT)",
-        "tests/config/rbe_autoconf_config_repos_output_base",
+        "bazel-rbe-tests/config/rbe_autoconf_config_repos_output_base",
         _ubuntu1604_bazel,
         "assert_output_base_cc_confs",
         "assert_output_base_java_confs",
@@ -526,7 +526,7 @@ sh_test(
     srcs = [":rbe_autoconf_output_base_config_dir_checks.sh"],
     args = [
         "$(location @rbe_autoconfig_root//:AUTOCONF_ROOT)",
-        "tests/config/rbe_autoconf_output_base",
+        "bazel-rbe-tests/config/rbe_autoconf_output_base",
         "test_config_dir",
         _ubuntu1604_bazel,
         "assert_output_base_cc_confs",


### PR DESCRIPTION
- add .bazelingorefile to ignore example repo directories
- move output_bases to use bazel-* gitignored dir
- add missing license headers and doc fixes