### PR TITLE
fix output_base test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 # Ignore all bazel-* symlinks. There is no full list since this can change
 # based on the name of the directory bazel is cloned into.
 /bazel-*
+/rbe-test-output/
 # Ignore outputs generated during Bazel bootstrapping.
 /output/
 # Python runtime generated from .bzl files.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -359,7 +359,7 @@ rbe_autoconfig(
     name = "rbe_autoconf_output_base",
     bazel_version = _ubuntu1604_bazel,
     create_testdata = True,
-    output_base = "bazel-rbe-tests/config/rbe_autoconf_output_base",
+    output_base = "rbe-test-output/config/rbe_autoconf_output_base",
     use_checked_in_confs = "False",
 )
 
@@ -368,7 +368,7 @@ rbe_autoconfig(
     bazel_version = _ubuntu1604_bazel,
     create_java_configs = False,
     create_testdata = True,
-    output_base = "bazel-rbe-tests/config/rbe_autoconf_output_base_no_java",
+    output_base = "rbe-test-output/config/rbe_autoconf_output_base_no_java",
     use_checked_in_confs = "False",
 )
 
@@ -377,7 +377,7 @@ rbe_autoconfig(
     bazel_version = _ubuntu1604_bazel,
     create_cc_configs = False,
     create_testdata = True,
-    output_base = "bazel-rbe-tests/config/rbe_autoconf_output_base_no_cc",
+    output_base = "rbe-test-output/config/rbe_autoconf_output_base_no_cc",
     use_checked_in_confs = "False",
 )
 
@@ -388,7 +388,7 @@ rbe_autoconfig(
         "local_config_sh",
     ],
     create_testdata = True,
-    output_base = "bazel-rbe-tests/config/rbe_autoconf_config_repos_output_base",
+    output_base = "rbe-test-output/config/rbe_autoconf_config_repos_output_base",
 )
 
 rbe_autoconfig(
@@ -396,7 +396,7 @@ rbe_autoconfig(
     bazel_version = _ubuntu1604_bazel,
     config_dir = "test_config_dir",
     create_testdata = True,
-    output_base = "bazel-rbe-tests/config/rbe_autoconf_output_base",
+    output_base = "rbe-test-output/config/rbe_autoconf_output_base",
     use_checked_in_confs = "False",
 )
 

--- a/tests/rbe_repo/BUILD
+++ b/tests/rbe_repo/BUILD
@@ -445,7 +445,7 @@ sh_test(
     srcs = [":rbe_autoconf_output_base_checks.sh"],
     args = [
         "$(location @rbe_autoconfig_root//:AUTOCONF_ROOT)",
-        "bazel-rbe-tests/config/rbe_autoconf_output_base",
+        "rbe-test-output/config/rbe_autoconf_output_base",
         _ubuntu1604_bazel,
         "assert_output_base_cc_confs",
         "assert_output_base_java_confs",
@@ -463,7 +463,7 @@ sh_test(
     srcs = [":rbe_autoconf_output_base_checks.sh"],
     args = [
         "$(location @rbe_autoconfig_root//:AUTOCONF_ROOT)",
-        "bazel-rbe-tests/config/rbe_autoconf_output_base_no_java",
+        "rbe-test-output/config/rbe_autoconf_output_base_no_java",
         _ubuntu1604_bazel,
         "assert_output_base_cc_confs",
         "assert_output_base_no_java_confs",
@@ -481,7 +481,7 @@ sh_test(
     srcs = [":rbe_autoconf_output_base_checks.sh"],
     args = [
         "$(location @rbe_autoconfig_root//:AUTOCONF_ROOT)",
-        "bazel-rbe-tests/config/rbe_autoconf_output_base_no_cc",
+        "rbe-test-output/config/rbe_autoconf_output_base_no_cc",
         _ubuntu1604_bazel,
         "assert_output_base_no_cc_confs",
         "assert_output_base_java_confs",
@@ -499,7 +499,7 @@ sh_test(
     srcs = [":rbe_autoconf_output_base_checks.sh"],
     args = [
         "$(location @rbe_autoconfig_root//:AUTOCONF_ROOT)",
-        "bazel-rbe-tests/config/rbe_autoconf_config_repos_output_base",
+        "rbe-test-output/config/rbe_autoconf_config_repos_output_base",
         _ubuntu1604_bazel,
         "assert_output_base_cc_confs",
         "assert_output_base_java_confs",
@@ -526,7 +526,7 @@ sh_test(
     srcs = [":rbe_autoconf_output_base_config_dir_checks.sh"],
     args = [
         "$(location @rbe_autoconfig_root//:AUTOCONF_ROOT)",
-        "bazel-rbe-tests/config/rbe_autoconf_output_base",
+        "rbe-test-output/config/rbe_autoconf_output_base",
         "test_config_dir",
         _ubuntu1604_bazel,
         "assert_output_base_cc_confs",

--- a/tests/rbe_repo/output_base.yaml
+++ b/tests/rbe_repo/output_base.yaml
@@ -16,7 +16,7 @@ steps:
 # usable for an RBE build.
 - name: 'l.gcr.io/google/bazel'
   args:
-  - --bazelrc=tests/config/rbe_autoconf_output_base/.latest.bazelrc
+  - --bazelrc=bazel-rbe-tests/config/rbe_autoconf_output_base/.latest.bazelrc
   - test
   - //examples/remotebuildexecution/hello_world/cc:say_hello_test
   - --config=remote
@@ -29,7 +29,7 @@ steps:
 # produces outputs that are usable for an RBE build.
 - name: 'l.gcr.io/google/bazel'
   args:
-  - --bazelrc=tests/config/rbe_autoconf_output_base/.latest.bazelrc
+  - --bazelrc=bazel-rbe-tests/config/rbe_autoconf_output_base/.latest.bazelrc
   - test
   - //examples/remotebuildexecution/hello_world/cc:say_hello_test
   - --config=remote

--- a/tests/rbe_repo/output_base.yaml
+++ b/tests/rbe_repo/output_base.yaml
@@ -16,7 +16,7 @@ steps:
 # usable for an RBE build.
 - name: 'l.gcr.io/google/bazel'
   args:
-  - --bazelrc=bazel-rbe-tests/config/rbe_autoconf_output_base/.latest.bazelrc
+  - --bazelrc=rbe-test-output/config/rbe_autoconf_output_base/.latest.bazelrc
   - test
   - //examples/remotebuildexecution/hello_world/cc:say_hello_test
   - --config=remote
@@ -29,7 +29,7 @@ steps:
 # produces outputs that are usable for an RBE build.
 - name: 'l.gcr.io/google/bazel'
   args:
-  - --bazelrc=bazel-rbe-tests/config/rbe_autoconf_output_base/.latest.bazelrc
+  - --bazelrc=rbe-test-output/config/rbe_autoconf_output_base/.latest.bazelrc
   - test
   - //examples/remotebuildexecution/hello_world/cc:say_hello_test
   - --config=remote


### PR DESCRIPTION
Missing change from my previous PR that caused a non blocking GCB run to fail (looks like GCB tries to get smart with bazel-* dirs).