### PR TITLE
use incompatible py toolchains flags by default

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -40,6 +40,7 @@ platforms:
     - "//configs/ubuntu16_04_clang:default-ubuntu16_04-clang-1.1-bazel_0.18.0-autoconfig_test"
     - "//configs/ubuntu16_04_clang:msan-ubuntu16_04-clang-1.1-bazel_0.18.0-autoconfig_test"
     test_flags:
+    - "--config=ci"
     - "--action_env=RBE_AUTOCONF_ROOT=/workdir"
     - "--action_env=PATH"
     - "--test_output=errors"

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,22 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The following flags are set to test use of new features for python toolchains
+# These flags will only work with Bazel 0.25.0 or above.
+build:ci --incompatible_use_python_toolchains
+build:ci --host_force_python=PY2
+test:ci --incompatible_use_python_toolchains
+test:ci --host_force_python=PY2
+run:ci --incompatible_use_python_toolchains
+run:ci --host_force_python=PY2


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/bazel-toolchains/issues/501
Adds the flag only to our buildkite CI configuration as GCB configs are using older versions of Bazel