### PR TITLE
Add pip dependencies of base images docker

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -420,3 +420,16 @@ load("//rules/rbe_repo:util.bzl", "rbe_autoconfig_root")
 # Needed for testing purposes. Creates a file that exposes
 # the value of RBE_AUTOCONF_ROOT
 rbe_autoconfig_root(name = "rbe_autoconfig_root")
+
+# Pull in dependencies of base_images_docker.
+load("@base_images_docker//package_managers:repositories.bzl", package_manager_deps = "deps")
+package_manager_deps()
+load("@io_bazel_rules_python//python:pip.bzl", "pip_import", "pip_repositories")
+pip_repositories()
+pip_import(
+    name = "pip_deps",
+    requirements = "@base_images_docker//package_managers:requirements-pip.txt",
+)
+load("@pip_deps//:requirements.bzl", "pip_install")
+pip_install()
+

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -423,13 +423,18 @@ rbe_autoconfig_root(name = "rbe_autoconfig_root")
 
 # Pull in dependencies of base_images_docker.
 load("@base_images_docker//package_managers:repositories.bzl", package_manager_deps = "deps")
+
 package_manager_deps()
+
 load("@io_bazel_rules_python//python:pip.bzl", "pip_import", "pip_repositories")
+
 pip_repositories()
+
 pip_import(
     name = "pip_deps",
     requirements = "@base_images_docker//package_managers:requirements-pip.txt",
 )
-load("@pip_deps//:requirements.bzl", "pip_install")
-pip_install()
 
+load("@pip_deps//:requirements.bzl", "pip_install")
+
+pip_install()

--- a/deps/base_images_docker.bzl
+++ b/deps/base_images_docker.bzl
@@ -13,4 +13,4 @@
 # limitations under the License.
 """Commit sha for GoogleContainerTools/base-images-docker."""
 
-version = "b9eb03584cde7f9a0acc45fc3ac8818a69fc0b2f"
+version = "b0893a7c5cbfcb91cc62f56e24dd242ddc564869"


### PR DESCRIPTION
This updates base images docker to the same version as #527 with fixes
for the build failures.