### PR TITLE
add tests that run RBE builds with external projects

### DIFF
--- a/bazelrc/bazel-0.27.0.bazelrc
+++ b/bazelrc/bazel-0.27.0.bazelrc
@@ -1,0 +1,58 @@
+# Copyright 2016 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This .bazelrc file contains all of the flags required for the provided
+# toolchain with Remote Build Execution.
+# Note your WORKSPACE must contain an rbe_autoconfig target with
+# name="rbe_default" to use these flags as-is.
+
+# Depending on how many machines are in the remote execution instance, setting
+# this higher can make builds faster by allowing more jobs to run in parallel.
+# Setting it too high can result in jobs that timeout, however, while waiting
+# for a remote machine to execute them.
+build:remote --jobs=50
+
+# Set several flags related to specifying the platform, toolchain and java
+# properties.
+# These flags should only be used as is for the rbe-ubuntu16-04 container
+# and need to be adapted to work with other toolchain containers.
+build:remote --host_javabase=@rbe_default//java:jdk
+build:remote --javabase=@rbe_default//java:jdk
+build:remote --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:remote --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:remote --crosstool_top=@rbe_default//cc:toolchain
+build:remote --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+# Platform flags:
+# The toolchain container used for execution is defined in the target indicated
+# by "extra_execution_platforms", "host_platform" and "platforms".
+# More about platforms: https://docs.bazel.build/versions/master/platforms.html
+build:remote --extra_toolchains=@rbe_default//config:cc-toolchain
+build:remote --extra_execution_platforms=@rbe_default//config:platform
+build:remote --host_platform=@rbe_default//config:platform
+build:remote --platforms=@rbe_default//config:platform
+
+# Starting with Bazel 0.27.0 strategies do not need to be explicitly
+# defined. See https://github.com/bazelbuild/bazel/issues/7480
+build:remote --define=EXECUTOR=remote
+
+# Enable remote execution so actions are performed on the remote systems.
+build:remote --remote_executor=grpcs://remotebuildexecution.googleapis.com
+
+# Set a higher timeout value, just in case.
+build:remote --remote_timeout=3600
+
+# Enable authentication. This will pick up application default credentials by
+# default. You can use --google_credentials=some_file.json to use a service
+# account credential instead.
+build:remote --google_default_credentials=true

--- a/tests/rbe_external_project/abseil.yaml
+++ b/tests/rbe_external_project/abseil.yaml
@@ -1,0 +1,28 @@
+# Basic test that builds Bazel on RBE using the latest Bazel version
+steps:
+# pull the abseil-cpp project
+- name: 'gcr.io/cloud-builders/git'
+  args:
+  - clone
+  - https://github.com/abseil/abseil-cpp.git
+  - external-src
+
+# modify the WORKSPACE file
+- name: 'gcr.io/gcp-runtimes/ubuntu_16_0_4'
+  args:
+  - ../tests/rbe_external_project/add_rbe_default.sh
+  dir: 'external-src'
+
+# Launch an RBE test command using the @rbe_default toolchain
+# configs.
+- name: 'l.gcr.io/google/bazel'
+  args:
+  - --bazelrc=../bazelrc/latest.bazelrc
+  - test
+  - --config=remote
+  - --remote_instance_name=projects/asci-toolchain/instances/default_instance
+  - --
+  - //absl/...
+  - -//absl/time/internal/cctz:time_zone_format_test
+  - -//absl/time/internal/cctz:time_zone_lookup_test
+  dir: 'external-src'

--- a/tests/rbe_external_project/add_rbe_default.sh
+++ b/tests/rbe_external_project/add_rbe_default.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Simple script to use bazel-toolchains srcs in the current client
+# and add the rbe_default repo to WORKSPACE if it does not exist
+# This script should be executed from the root of an external project's srcs
+
+set -ex
+mv WORKSPACE WORKSPACE.bak
+
+if grep -q rbe_default "WORKSPACE.bak"; then
+  sed '0,/load/{s/load/local_repository(\n    name = \"bazel_toolchains\",\n    path = \"..\/\",\n)\nload/}' WORKSPACE.bak > WORKSPACE
+else
+  sed '0,/load/{s/load/local_repository(\n    name = \"bazel_toolchains\",\n    path = \"..\/\",\n)\nload(\"@bazel_toolchains\/\/rules:rbe_repo.bzl\", \"rbe_autoconfig\")\nrbe_autoconfig(name = \"rbe_default\")\nload/}' WORKSPACE.bak > WORKSPACE
+fi
+
+if [ -f ".bazelrc" ]; then
+    rm .bazelrc
+fi

--- a/tests/rbe_external_project/baselisk.sh
+++ b/tests/rbe_external_project/baselisk.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Simple script to use bazel-toolchains srcs in the current client
+# and add the rbe_default repo to WORKSPACE if it does not exist
+# This script should be executed from the root of an external project's srcs
+
+set -ex
+wget https://github.com/bazelbuild/bazelisk/releases/download/v0.0.7/bazelisk-linux-amd64
+mv bazelisk-linux-amd64 bazelisk
+chmod 755 bazelisk

--- a/tests/rbe_external_project/bazel.yaml
+++ b/tests/rbe_external_project/bazel.yaml
@@ -1,0 +1,37 @@
+# Basic test that builds Bazel on RBE using the latest Bazel version
+steps:
+# pull the abseil-cpp project
+- name: 'gcr.io/cloud-builders/git'
+  args:
+  - clone
+  - https://github.com/bazelbuild/bazel.git
+  - external-src
+
+# modify the WORKSPACE file & delete the existing .bazelrc file
+- name: 'gcr.io/gcp-runtimes/ubuntu_16_0_4'
+  args:
+  - ../tests/rbe_external_project/add_rbe_default.sh
+  dir: 'external-src'
+
+# Launch an RBE test command using the @rbe_default toolchain
+# configs.
+- name: 'l.gcr.io/google/bazel'
+  args:
+  - --bazelrc=../bazelrc/latest.bazelrc
+  - test
+  - --config=remote
+  - --remote_instance_name=projects/asci-toolchain/instances/default_instance
+  - --
+  - //src/test/java/...
+  - -//src/test/java/com/google/devtools/build/android/...
+  - -//src/test/java/com/google/devtools/build/lib:sandbox-tests
+  - -//src/test/java/com/google/devtools/build/lib/shell:CommandUsingLinuxSandboxTest
+  - -//src/test/java/com/google/devtools/build/lib:vfs_inmemoryfs_test
+  - -//src/test/java/com/google/devtools/build/lib/blackbox/tests:PythonBlackBoxTest
+  - -//src/test/java/com/google/devtools/build/lib/rules/objc:ObjcRulesTests
+  - -//src/test/java/com/google/devtools/build/lib:worker-tests
+  - -//src/test/java/com/google/devtools/build/lib/buildeventstream/transports:BuildEventTransportTest
+  - -//src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace:BazelEmbeddedSkylarkBlackBoxTest
+  - -//src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace:WorkspaceBlackBoxTest
+  dir: 'external-src'
+timeout: 1200s

--- a/tests/rbe_external_project/bazel_baselisk_rc.yaml
+++ b/tests/rbe_external_project/bazel_baselisk_rc.yaml
@@ -1,0 +1,45 @@
+steps:
+# pull the abseil-cpp project
+- name: 'gcr.io/cloud-builders/git'
+  args:
+  - clone
+  - https://github.com/bazelbuild/bazel.git
+  - external-src
+
+# Install bazelisk
+- name: 'gcr.io/cloud-builders/wget'
+  entrypoint: bash
+  args:
+  - ./tests/rbe_external_project/baselisk.sh
+
+# modify the WORKSPACE file & delete the existing .bazelrc file
+- name: 'gcr.io/gcp-runtimes/ubuntu_16_0_4'
+  args:
+  - ../tests/rbe_external_project/add_rbe_default.sh
+  dir: 'external-src'
+
+# Launch an RBE test command using the @rbe_default toolchain
+# configs.
+- name: 'l.gcr.io/google/bazel'
+  entrypoint: ../bazelisk
+  env: ['USE_BAZEL_VERSION=${_BAZEL_VERSION}']
+  args:
+  - --bazelrc=../bazelrc/bazel-${_BAZELRC_FILE_VERSION}.bazelrc
+  - test
+  - --config=remote
+  - --remote_instance_name=projects/asci-toolchain/instances/default_instance
+  - --
+  - //src/test/java/...
+  - -//src/test/java/com/google/devtools/build/android/...
+  - -//src/test/java/com/google/devtools/build/lib:sandbox-tests
+  - -//src/test/java/com/google/devtools/build/lib/shell:CommandUsingLinuxSandboxTest
+  - -//src/test/java/com/google/devtools/build/lib:vfs_inmemoryfs_test
+  - -//src/test/java/com/google/devtools/build/lib/blackbox/tests:PythonBlackBoxTest
+  - -//src/test/java/com/google/devtools/build/lib/rules/objc:ObjcRulesTests
+  - -//src/test/java/com/google/devtools/build/lib:worker-tests
+  - -//src/test/java/com/google/devtools/build/lib/buildeventstream/transports:BuildEventTransportTest
+  - -//src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace:BazelEmbeddedSkylarkBlackBoxTest
+  - -//src/test/java/com/google/devtools/build/lib/blackbox/tests/workspace:WorkspaceBlackBoxTest
+  dir: 'external-src'
+
+timeout: 1200s


### PR DESCRIPTION
Tests run as GCB builds.
- Adding test that run with latest bazel with latest bazerc file for abseil and bazel

- Also added test that can run with arbitrary bazel version (including rc
versions as it uses basilisk) and arbitrary bazelrc file (i.e., does
not need to match bazel version)

- Also added a 0.27 bazelrc file so we can start testing early
(particularly due to https://github.com/bazelbuild/bazel/issues/8469)