### PR TITLE
use external project for bazel legacy tests

### DIFF
--- a/tests/rbe_repo/bazel_legacy_configs.yaml
+++ b/tests/rbe_repo/bazel_legacy_configs.yaml
@@ -19,18 +19,19 @@ steps:
 # These tests should only be run for versions of Bazel < 0.25.0
 - name: 'l.gcr.io/google/bazel:${_BAZEL_VERSION}'
   args:
-  - --bazelrc=bazelrc/.bazelrc.notoolchain
+  - --bazelrc=../../../../bazelrc/.bazelrc.notoolchain
   - test
-  - //examples/remotebuildexecution/hello_world/cc:say_hello_test
+  - //:say_hello_test
   - --config=remote
-  - --host_javabase=//configs/ubuntu16_04_clang/${_CONTAINER_MAJOR_VERSION}/bazel_${_BAZEL_VERSION}/java:jdk
-  - --javabase=//configs/ubuntu16_04_clang/${_CONTAINER_MAJOR_VERSION}/bazel_${_BAZEL_VERSION}/java:jdk
+  - --host_javabase=@bazel_toolchains//configs/ubuntu16_04_clang/${_CONTAINER_MAJOR_VERSION}/bazel_${_BAZEL_VERSION}/java:jdk
+  - --javabase=@bazel_toolchains//configs/ubuntu16_04_clang/${_CONTAINER_MAJOR_VERSION}/bazel_${_BAZEL_VERSION}/java:jdk
   - --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
   - --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-  - --crosstool_top=//configs/ubuntu16_04_clang/${_CONTAINER_MAJOR_VERSION}/bazel_${_BAZEL_VERSION}/cc:toolchain
+  - --crosstool_top=@bazel_toolchains//configs/ubuntu16_04_clang/${_CONTAINER_MAJOR_VERSION}/bazel_${_BAZEL_VERSION}/cc:toolchain
   - --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-  - --extra_toolchains=//configs/ubuntu16_04_clang/${_CONTAINER_MAJOR_VERSION}/bazel_${_BAZEL_VERSION}/config:cc-toolchain
-  - --extra_execution_platforms=//configs/ubuntu16_04_clang/${_CONTAINER_MAJOR_VERSION}/bazel_${_BAZEL_VERSION}/config:platform
-  - --host_platform=//configs/ubuntu16_04_clang/${_CONTAINER_MAJOR_VERSION}/bazel_${_BAZEL_VERSION}/config:platform
-  - --platforms=//configs/ubuntu16_04_clang/${_CONTAINER_MAJOR_VERSION}/bazel_${_BAZEL_VERSION}/config:platform
+  - --extra_toolchains=@bazel_toolchains//configs/ubuntu16_04_clang/${_CONTAINER_MAJOR_VERSION}/bazel_${_BAZEL_VERSION}/config:cc-toolchain
+  - --extra_execution_platforms=@bazel_toolchains//configs/ubuntu16_04_clang/${_CONTAINER_MAJOR_VERSION}/bazel_${_BAZEL_VERSION}/config:platform
+  - --host_platform=@bazel_toolchains//configs/ubuntu16_04_clang/${_CONTAINER_MAJOR_VERSION}/bazel_${_BAZEL_VERSION}/config:platform
+  - --platforms=@bazel_toolchains//configs/ubuntu16_04_clang/${_CONTAINER_MAJOR_VERSION}/bazel_${_BAZEL_VERSION}/config:platform
   - --remote_instance_name=projects/asci-toolchain/instances/default_instance
+  dir: 'tests/rbe_repo/examples/bazel_toolchains_client'

--- a/tests/rbe_repo/bazel_legacy_rbe_default.yaml
+++ b/tests/rbe_repo/bazel_legacy_rbe_default.yaml
@@ -16,7 +16,7 @@ steps:
 # that verifies that @rbe_default works for Bazel 0.20.0 - 0.25.0
 # These tests are separate from bazel_tests_cloudbuild.yaml as those
 # tests depend on the bazelrc files numbered by versions.
-# However, tests covered by this file have a bazerc file that did
+# However, tests covered by this file have a bazelrc file that did
 # not use @rbe_default.
 # Starting with Bazel 0.26.0, @rbe_default is used in all bazelrc
 # files, so bazel_tests_cloudbuild.yaml covers it.

--- a/tests/rbe_repo/bazel_legacy_rbe_default.yaml
+++ b/tests/rbe_repo/bazel_legacy_rbe_default.yaml
@@ -16,14 +16,15 @@ steps:
 # that verifies that @rbe_default works for Bazel 0.20.0 - 0.25.0
 # These tests are separate from bazel_tests_cloudbuild.yaml as those
 # tests depend on the bazelrc files numbered by versions.
-# However, tests covered by this file have a bazerc file that did 
-# not use @rbe_default. 
+# However, tests covered by this file have a bazerc file that did
+# not use @rbe_default.
 # Starting with Bazel 0.26.0, @rbe_default is used in all bazelrc
 # files, so bazel_tests_cloudbuild.yaml covers it.
 - name: 'l.gcr.io/google/bazel:${_BAZEL_VERSION}'
   args:
-  - --bazelrc=tests/rbe_repo/bazelrc/pre0260.bazelrc
+  - --bazelrc=../../bazelrc/pre0260.bazelrc
   - test
-  - //examples/remotebuildexecution/hello_world/cc:say_hello_test
+  - //:say_hello_test
   - --config=remote
   - --remote_instance_name=projects/asci-toolchain/instances/default_instance
+  dir: 'tests/rbe_repo/examples/bazel_toolchains_client'


### PR DESCRIPTION
Legacy tests are failing with newer version of rules_go as our deps in the bazel-toolchains repo realistically cannot be executed with older versions of Bazel. Switching to using the external repo that has a simple C target only.

Should unblock https://github.com/bazelbuild/bazel-toolchains/pull/560