### PR TITLE
Remove use of debian8

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -341,9 +341,9 @@ rbe_autoconfig(
     name = "rbe_autoconf_custom_container",
     bazel_version = _ubuntu1604_bazel,
     create_testdata = True,
-    digest = "sha256:eb9f72ddde60080912fed8a6f40c5a42c13ec6c890c0709c119213b199804456",
-    registry = _ubuntu1604_registry,
-    repository = "google/clang-debian9",
+    digest = "sha256:8fecd4573a081f51ff6103fea84b1e108cca75f0dedf5377eb2124b80f2d5f8f",
+    registry = "gcr.io",
+    repository = "cloud-builders/bazel",
 )
 
 rbe_autoconfig(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -341,9 +341,9 @@ rbe_autoconfig(
     name = "rbe_autoconf_custom_container",
     bazel_version = _ubuntu1604_bazel,
     create_testdata = True,
-    digest = "sha256:cda3a8608d0fc545dffc6c68f6cfab8eda280c7a1558bde0753ed2e8e3006224",
+    digest = "sha256:eb9f72ddde60080912fed8a6f40c5a42c13ec6c890c0709c119213b199804456",
     registry = _ubuntu1604_registry,
-    repository = "google/rbe-debian8",
+    repository = "google/clang-debian9",
 )
 
 rbe_autoconfig(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -341,9 +341,9 @@ rbe_autoconfig(
     name = "rbe_autoconf_custom_container",
     bazel_version = _ubuntu1604_bazel,
     create_testdata = True,
-    digest = "sha256:8fecd4573a081f51ff6103fea84b1e108cca75f0dedf5377eb2124b80f2d5f8f",
-    registry = "gcr.io",
-    repository = "cloud-builders/bazel",
+    digest = "sha256:9ed4a6bafffb0ca08389c4445955217802074d07bac9acff6b661239926555ed",
+    registry = "l.gcr.io",
+    repository = "google/bazel",
 )
 
 rbe_autoconfig(

--- a/tests/rbe_repo/BUILD
+++ b/tests/rbe_repo/BUILD
@@ -315,7 +315,7 @@ file_test(
 file_test(
     name = "rbe_autoconf_custom_container_sha_test",
     file = "@rbe_autoconf_custom_container//test:config/test.BUILD",
-    regexp = "cda3a8608d0fc545dffc6c68f6cfab8eda280c7a1558bde0753ed2e8e3006224",
+    regexp = "9ed4a6bafffb0ca08389c4445955217802074d07bac9acff6b661239926555ed",
 )
 
 file_test(


### PR DESCRIPTION
debian8 is no longer supported with bazel 0.27.0, switch tests that use a custom container to use the bazel cloud builder. This PR is ready to merge as soon as CI passes.