### PR TITLE
Fix bad Starlark string escapes

### DIFF
--- a/rules/rbe_repo/container.bzl
+++ b/rules/rbe_repo/container.bzl
@@ -50,7 +50,7 @@ def _create_docker_cmd(
     for config_repo in config_repos:
         symlinks_cmd = ("find $(" + _BAZELISK_PATH + " info output_base)/" +
                         _EXTERNAL_FOLDER_PREFIX + config_repo +
-                        " -type l -exec bash -c 'ln -f \"$(readlink -m \"$0\")\" \"$0\"' {} \;")
+                        " -type l -exec bash -c 'ln -f \"$(readlink -m \"$0\")\" \"$0\"' {} \\;")
         deref_symlinks_cmd.append(symlinks_cmd)
     deref_symlinks_cmd = " && ".join(deref_symlinks_cmd)
 

--- a/rules/rbe_repo/util.bzl
+++ b/rules/rbe_repo/util.bzl
@@ -208,7 +208,7 @@ def copy_to_test_dir(ctx):
     print_exec_results("copy test output files", result, True, args)
 
     # Rename BUILD files
-    ctx.file("rename_build_files.sh", "find ./test -name \"BUILD\" -exec sh -c 'mv \"$1\" \"$(dirname $1)/test.BUILD\"' _ {} \;", True)
+    ctx.file("rename_build_files.sh", "find ./test -name \"BUILD\" -exec sh -c 'mv \"$1\" \"$(dirname $1)/test.BUILD\"' _ {} \\;", True)
     result = ctx.execute(["./rename_build_files.sh"])
     print_exec_results("Rename BUILD files in test output", result, True, args)
 


### PR DESCRIPTION
This will be required by Bazel 1.0 (see incompatible_restrict_string_escapes).