### PR TITLE
Add create_exec_properties_dict tests

### DIFF
--- a/.bazelversion
+++ b/.bazelversion
@@ -1,1 +1,0 @@
-last_downstream_green

--- a/.bazelversion
+++ b/.bazelversion
@@ -1,0 +1,1 @@
+last_downstream_green

--- a/tests/rules/experimental/rbe/BUILD
+++ b/tests/rules/experimental/rbe/BUILD
@@ -1,5 +1,21 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 load("//rules/experimental/rbe:exec_properties.bzl", "create_exec_properties_dict")
 load("//configs/ubuntu16_04_clang:versions.bzl", "LATEST")
+
+CONTAINER_IMAGE = "docker://l.gcr.io/google/rbe-ubuntu16-04@%s" % LATEST
 
 # Test the docker_privileged property
 constraint_setting(name = "constraint_privileged")
@@ -13,7 +29,7 @@ platform(
     name = "platform_privileged_on",
     constraint_values = [":constraint_privileged_on"],
     exec_properties = create_exec_properties_dict(
-        container_image = "docker://marketplace.gcr.io/google/rbe-ubuntu16-04@%s" % LATEST,
+        container_image = CONTAINER_IMAGE,
         docker_privileged = True,
     ),
 )
@@ -45,7 +61,7 @@ platform(
     name = "platform_network_enabled",
     constraint_values = [":constraint_network_enabled"],
     exec_properties = create_exec_properties_dict(
-        container_image = "docker://marketplace.gcr.io/google/rbe-ubuntu16-04@%s" % LATEST,
+        container_image = CONTAINER_IMAGE,
         docker_network_enabled = True,
     ),
 )

--- a/tests/rules/experimental/rbe/BUILD
+++ b/tests/rules/experimental/rbe/BUILD
@@ -1,0 +1,65 @@
+load("//rules/experimental/rbe:exec_properties.bzl", "create_exec_properties_dict")
+load("//configs/ubuntu16_04_clang:versions.bzl", "LATEST")
+
+# Test the docker_privileged property
+constraint_setting(name = "constraint_privileged")
+constraint_value(
+    name = "constraint_privileged_on",
+    constraint_setting = ":constraint_privileged",
+)
+
+platform(
+    name = "platform_privileged_on",
+    constraint_values = [":constraint_privileged_on"],
+    exec_properties = create_exec_properties_dict(
+        container_image =  "docker://marketplace.gcr.io/google/rbe-ubuntu16-04@%s" % LATEST,
+        docker_privileged = True,
+    ),
+)
+
+# privileged_off_test should run with @rbe_default//config:platform
+sh_test(
+    name = "privileged_off_test",
+    srcs = ["privileged_off.sh"],
+)
+
+# privileged_on_test should run with :platform_privileged_on
+sh_test(
+    name = "privileged_on_test",
+    srcs = ["privileged_on.sh"],
+    exec_compatible_with = [
+        ":constraint_privileged_on",
+    ],
+)
+
+# Test the docker_network_enabled property
+constraint_setting(name = "constraint_network")
+constraint_value(
+    name = "constraint_network_enabled",
+    constraint_setting = ":constraint_network",
+)
+
+platform(
+    name = "platform_network_enabled",
+    constraint_values = [":constraint_network_enabled"],
+    exec_properties = create_exec_properties_dict(
+        container_image =  "docker://marketplace.gcr.io/google/rbe-ubuntu16-04@%s" % LATEST,
+        docker_network_enabled = True,
+    ),
+)
+
+# network_disabled_test should run with @rbe_default//config:platform
+sh_test(
+    name = "network_disabled_test",
+    srcs = ["network_disabled.sh"],
+)
+
+# network_enabled_test should run with :platform_network_enabled
+sh_test(
+    name = "network_enabled_test",
+    srcs = ["network_enabled.sh"],
+    exec_compatible_with = [
+        ":constraint_network_enabled",
+    ],
+)
+

--- a/tests/rules/experimental/rbe/BUILD
+++ b/tests/rules/experimental/rbe/BUILD
@@ -3,6 +3,7 @@ load("//configs/ubuntu16_04_clang:versions.bzl", "LATEST")
 
 # Test the docker_privileged property
 constraint_setting(name = "constraint_privileged")
+
 constraint_value(
     name = "constraint_privileged_on",
     constraint_setting = ":constraint_privileged",
@@ -12,7 +13,7 @@ platform(
     name = "platform_privileged_on",
     constraint_values = [":constraint_privileged_on"],
     exec_properties = create_exec_properties_dict(
-        container_image =  "docker://marketplace.gcr.io/google/rbe-ubuntu16-04@%s" % LATEST,
+        container_image = "docker://marketplace.gcr.io/google/rbe-ubuntu16-04@%s" % LATEST,
         docker_privileged = True,
     ),
 )
@@ -34,6 +35,7 @@ sh_test(
 
 # Test the docker_network_enabled property
 constraint_setting(name = "constraint_network")
+
 constraint_value(
     name = "constraint_network_enabled",
     constraint_setting = ":constraint_network",
@@ -43,7 +45,7 @@ platform(
     name = "platform_network_enabled",
     constraint_values = [":constraint_network_enabled"],
     exec_properties = create_exec_properties_dict(
-        container_image =  "docker://marketplace.gcr.io/google/rbe-ubuntu16-04@%s" % LATEST,
+        container_image = "docker://marketplace.gcr.io/google/rbe-ubuntu16-04@%s" % LATEST,
         docker_network_enabled = True,
     ),
 )
@@ -62,4 +64,3 @@ sh_test(
         ":constraint_network_enabled",
     ],
 )
-

--- a/tests/rules/experimental/rbe/network_disabled.sh
+++ b/tests/rules/experimental/rbe/network_disabled.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+curl https://www.google.com
+
+# Expecting curl to fail. Return the return code.
+if [ $? -eq 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/rules/experimental/rbe/network_disabled.sh
+++ b/tests/rules/experimental/rbe/network_disabled.sh
@@ -1,8 +1,22 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #!/bin/bash
 
 curl https://www.google.com
 
-# Expecting curl to fail. Return the return code.
+# Expecting curl to fail. Return the inverse of the return code.
 if [ $? -eq 0 ]; then
   exit 1
 fi

--- a/tests/rules/experimental/rbe/network_enabled.sh
+++ b/tests/rules/experimental/rbe/network_enabled.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+curl https://www.google.com

--- a/tests/rules/experimental/rbe/network_enabled.sh
+++ b/tests/rules/experimental/rbe/network_enabled.sh
@@ -1,3 +1,19 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #!/bin/bash
 
+# curl returns zero on success and not zero on failure.
+# This test returns the error code that curl returns.
 curl https://www.google.com

--- a/tests/rules/experimental/rbe/privileged_off.sh
+++ b/tests/rules/experimental/rbe/privileged_off.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep "Seccomp:[[:space:]]*2"  /proc/self/status

--- a/tests/rules/experimental/rbe/privileged_off.sh
+++ b/tests/rules/experimental/rbe/privileged_off.sh
@@ -1,3 +1,19 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #!/bin/bash
 
+# The value that /proc/self/status prints out for Seccomp is an indication of whether the container has priveleged mode.
+# A value of 2 indicates that it does not.
 grep "Seccomp:[[:space:]]*2"  /proc/self/status

--- a/tests/rules/experimental/rbe/privileged_on.sh
+++ b/tests/rules/experimental/rbe/privileged_on.sh
@@ -1,3 +1,19 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #!/bin/bash
 
+# The value that /proc/self/status prints out for Seccomp is an indication of whether the container has priveleged mode.
+# A value of 0 indicates that it does.
 grep "Seccomp:[[:space:]]*0"  /proc/self/status

--- a/tests/rules/experimental/rbe/privileged_on.sh
+++ b/tests/rules/experimental/rbe/privileged_on.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep "Seccomp:[[:space:]]*0"  /proc/self/status


### PR DESCRIPTION
Create some tests that run on RBE with platforms with various exec_properties that are populated using create_exec_properties_dict()

Currently, I added only tests for docker_privileged=True/False and for docker_network_enabled=True/False. But this PR provides a skeleton that demonstrates how other properties should be tested.

In order to run these tests, bazel needs to run with
--extra_execution_platforms=@rbe_default//config:platform,//tests/rules/experimental/rbe:platform_privileged_on,//tests/rules/experimental/rbe:platform_network_enabled

I have not yet piped these test into any pipeline.
One option is to pipe these tests as presubmit tests of bazel-toolchains. This cannot yet be done because these tests can only run on bazel 0.29 and up and that container does not yet exist. The reason why it is not compatible with older bazel versions is because platform does not have an exec_properties in those versions.

However, what I really want to do is to pipe these tests as bazel buildkite downstream tests (see https://github.com/bazelbuild/continuous-integration/blob/master/buildkite/README.md#configuring-a-pipeline).
In order to do that, .bazelci/presubmit.yml needs to first be converted to a newer format. I plan to do this in a separate pull request.