### PR TITLE
Make the rbe_exec_properties tests run on the current bazel version.

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -50,7 +50,6 @@ tasks:
     # Run tests on RBE. These tests run on platforms with various execution
     # properties. the tests verify that the approriate properties are set (or not set).
     # The properties are configured on the platforms using create_exec_properties_dict().
-    bazel: 0.29.0rc7
     platform: rbe_ubuntu1604
     test_targets:
     - "--"


### PR DESCRIPTION
The rbe_exec_properties tests need at least bazel 0.29 to run. Now that bazel 0.29 is released we can remove the specific bazel version from the test configuration.