### PR TITLE
add warning if current running bazel is ahead of bazel-toolchains repo

### DIFF
--- a/rules/rbe_repo/checked_in.bzl
+++ b/rules/rbe_repo/checked_in.bzl
@@ -103,7 +103,7 @@ def validateUseOfCheckedInConfigs(
         print("%s not using checked in configs as detect_java_home was set to True " % name)
         return None, None
     if bazel_rc_version:
-        print("%s not using checked in configs as hazel rc version was used " % name)
+        print("%s not using checked in configs as bazel rc version was used " % name)
         return None, None
 
     if not base_container_digest:

--- a/rules/rbe_repo/version_check.bzl
+++ b/rules/rbe_repo/version_check.bzl
@@ -60,10 +60,12 @@ def _check_bazel_version(bazel_version_fallback):
                "was not defined explicitly in rbe_autoconfig target. " +
                "Falling back to '%s'") % bazel_version_fallback)
         return bazel_version_fallback
+
     # If running a release that is not an RC, print a warning if the
     # fallback (latest known in this repo) is old
-    if (native.bazel_version.find("rc")==-1 and
+    if (native.bazel_version.find("rc") == -1 and
         native.bazel_version > bazel_version_fallback):
         print("\nCurrent running Bazel is ahead of bazel-toolchains repo. " +
-              "Please update your pin to bazel-toolchains repo.")
+              "Please update your pin to bazel-toolchains repo in your " +
+              "WORKSPACE file.")
     return native.bazel_version

--- a/rules/rbe_repo/version_check.bzl
+++ b/rules/rbe_repo/version_check.bzl
@@ -60,4 +60,7 @@ def _check_bazel_version(bazel_version_fallback):
                "was not defined explicitly in rbe_autoconfig target. " +
                "Falling back to '%s'") % bazel_version_fallback)
         return bazel_version_fallback
+    if native.bazel_version > bazel_version_fallback:
+        print("\nCurrent running Bazel is ahead of bazel-toolchains repo. " +
+              "Please update your pin to bazel-toolchains repo.")
     return native.bazel_version

--- a/rules/rbe_repo/version_check.bzl
+++ b/rules/rbe_repo/version_check.bzl
@@ -60,7 +60,10 @@ def _check_bazel_version(bazel_version_fallback):
                "was not defined explicitly in rbe_autoconfig target. " +
                "Falling back to '%s'") % bazel_version_fallback)
         return bazel_version_fallback
-    if native.bazel_version > bazel_version_fallback:
+    # If running a release that is not an RC, print a warning if the
+    # fallback (latest known in this repo) is old
+    if (native.bazel_version.find("rc")==-1 and
+        native.bazel_version > bazel_version_fallback):
         print("\nCurrent running Bazel is ahead of bazel-toolchains repo. " +
               "Please update your pin to bazel-toolchains repo.")
     return native.bazel_version


### PR DESCRIPTION
This warning should enable users to know when its unlikely to get toolchain configs that are checked in after a bazel upgrade.