### PR TITLE
Remove jdk_version from create_exec_properties_dict.

### DIFF
--- a/rules/experimental/rbe/exec_properties.bzl
+++ b/rules/experimental/rbe/exec_properties.bzl
@@ -221,10 +221,6 @@ PARAMS = {
         key = "gceMachineType",
         verifier_fcn = _verify_string,
     ),
-    "jdk_version": struct(
-        key = "jdk-version",
-        verifier_fcn = _verify_string,
-    ),
     "os_family": struct(
         key = "OSFamily",
         verifier_fcn = _verify_os,


### PR DESCRIPTION
This property is not actually used by RBE to target worker pools by JDK version like might have been expected.
It should not be a user facing property.