### PR TITLE
Add ISA property

### DIFF
--- a/rules/exec_properties/exec_properties.bzl
+++ b/rules/exec_properties/exec_properties.bzl
@@ -189,6 +189,10 @@ PARAMS = {
         key = "gceMachineType",
         verifier_fcn = _verify_string,
     ),
+    "isa": struct(
+        key = "ISA",
+        verifier_fcn = _verify_string,
+    ),
     "os_family": struct(
         key = "OSFamily",
         verifier_fcn = _verify_os,


### PR DESCRIPTION
This allows for a standard instruction set architecture to bet set when using create_rbe_exec_properties_dict (as per https://github.com/bazelbuild/remote-apis/blob/master/build/bazel/remote/execution/v2/platform.md)