### PR TITLE
Remove unused argument in print statement

### DIFF
--- a/rules/rbe_repo/checked_in.bzl
+++ b/rules/rbe_repo/checked_in.bzl
@@ -202,7 +202,6 @@ def validateUseOfCheckedInConfigs(
                "and/or 'create_cc_configs = %s' passed as attrs") %
               (
                   name,
-                  bazel_version,
                   str(bazel_compat_configs),
                   env,
                   config_repos,


### PR DESCRIPTION
Resolves #836

This argument was not used. I'm not sure if it was useful so this PR proposes to remove it entirely.

I'd be happy to add to the print statement in this PR if anyone feels differently.