### PR TITLE
Docker run: override the user as well

### DIFF
--- a/rules/rbe_repo/extract.sh.tpl
+++ b/rules/rbe_repo/extract.sh.tpl
@@ -32,7 +32,7 @@ fi
 %{copy_data_cmd}
 
 # Pass an empty entrypoint to override any set by default in the container.
-id=$(${DOCKER} run -d --entrypoint "" %{docker_run_flags} %{image_name} %{commands})
+id=$(${DOCKER} run -d --entrypoint "" --user root %{docker_run_flags} %{image_name} %{commands})
 
 ${DOCKER} wait $id
 # Check the docker logs contain the expected 'created outputs_tar' string


### PR DESCRIPTION
Currently, rbe_autoconfig fails for images that have a default USER set in the Dockerfile.

Fixes #860.