### PR TITLE
Invoke rbe_autoconf_checks in output base tests

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -458,6 +458,7 @@ rbe_autoconfig(
     name = "rbe_autoconf_output_base_config_dir",
     bazel_version = _ubuntu1604_bazel,
     create_testdata = True,
+    export_configs = True,
     toolchain_config_spec_name = "test_config_dir",
     toolchain_config_suite_spec = {
         "container_registry": rbe_default_repo()["container_registry"],

--- a/rules/rbe_repo/util.bzl
+++ b/rules/rbe_repo/util.bzl
@@ -202,8 +202,8 @@ def copy_to_test_dir(ctx):
       ctx: the Bazel context object.
     """
 
-    # Copy all files to the test directory
-    args = ["bash", "-c", "mkdir ./.test && cp -r ./* ./.test && mv ./.test ./test"]
+    # Copy all files to the test directory, including the output into RBE_AUTOCONF_ROOT contents
+    args = ["bash", "-c", ("mkdir ./.test && cp -r ./* ./.test && cp -r %s ./.test/rbe_autoconf_root && mv ./.test ./test" % ctx.os.environ.get(AUTOCONF_ROOT, None))]
     result = ctx.execute(args)
     print_exec_results("copy test output files", result, True, args)
 

--- a/rules/rbe_repo/util.bzl
+++ b/rules/rbe_repo/util.bzl
@@ -202,8 +202,13 @@ def copy_to_test_dir(ctx):
       ctx: the Bazel context object.
     """
 
-    # Copy all files to the test directory, including the output into RBE_AUTOCONF_ROOT contents
-    args = ["bash", "-c", ("mkdir ./.test && cp -r ./* ./.test && cp -r %s ./.test/rbe_autoconf_root && mv ./.test ./test" % ctx.os.environ.get(AUTOCONF_ROOT, None))]
+    # Copy all files to the test directory, including the output into RBE_AUTOCONF_ROOT contents if available
+    copy_autoconf_root_command = ""
+    autoconf_root = ctx.os.environ.get(AUTOCONF_ROOT, None)
+    if autoconf_root:
+        copy_autoconf_root_command = "cp -r %s ./.test/rbe_autoconf_root &&" % autoconf_root
+
+    args = ["bash", "-c", ("mkdir ./.test && cp -r ./* ./.test && %s mv ./.test ./test" % copy_autoconf_root_command)]
     result = ctx.execute(args)
     print_exec_results("copy test output files", result, True, args)
 

--- a/tests/rbe_repo/BUILD
+++ b/tests/rbe_repo/BUILD
@@ -490,7 +490,7 @@ sh_test(
     name = "rbe_autoconf_output_base_test",
     srcs = [":rbe_autoconf_output_base_config_dir_checks.sh"],
     args = [
-        "$(location @rbe_autoconfig_root//:AUTOCONF_ROOT)",
+        "$(location @rbe_autoconf_output_base//test:empty)",
         "rbe-test-output/config/rbe_autoconf_output_base",
         "9.0.0",
         _ubuntu1604_bazel,
@@ -500,8 +500,8 @@ sh_test(
     ],
     data = [
         ":rbe_autoconf_checks.sh",
+        "@rbe_autoconf_output_base//test:empty",
         "@rbe_autoconf_output_base//test:exported_testdata",
-        "@rbe_autoconfig_root//:AUTOCONF_ROOT",
     ],
 )
 
@@ -538,7 +538,7 @@ sh_test(
     name = "rbe_autoconf_output_base_no_java_test",
     srcs = [":rbe_autoconf_output_base_config_dir_checks.sh"],
     args = [
-        "$(location @rbe_autoconfig_root//:AUTOCONF_ROOT)",
+        "$(location @rbe_autoconf_output_base_no_java//test:empty)",
         "rbe-test-output/config/rbe_autoconf_output_base_no_java",
         _ubuntu1604_bazel,
         "assert_output_base_cc_confs",
@@ -547,8 +547,8 @@ sh_test(
     ],
     data = [
         ":rbe_autoconf_checks.sh",
+        "@rbe_autoconf_output_base_no_java//test:empty",
         "@rbe_autoconf_output_base_no_java//test:exported_testdata",
-        "@rbe_autoconfig_root//:AUTOCONF_ROOT",
     ],
 )
 
@@ -556,7 +556,7 @@ sh_test(
     name = "rbe_autoconf_output_base_no_cc_test",
     srcs = [":rbe_autoconf_output_base_config_dir_checks.sh"],
     args = [
-        "$(location @rbe_autoconfig_root//:AUTOCONF_ROOT)",
+        "$(location @rbe_autoconf_output_base_no_cc//test:empty)",
         "rbe-test-output/config/rbe_autoconf_output_base_no_cc",
         "9.0.0",
         _ubuntu1604_bazel,
@@ -566,8 +566,8 @@ sh_test(
     ],
     data = [
         ":rbe_autoconf_checks.sh",
+        "@rbe_autoconf_output_base_no_cc//test:empty",
         "@rbe_autoconf_output_base_no_cc//test:exported_testdata",
-        "@rbe_autoconfig_root//:AUTOCONF_ROOT",
     ],
 )
 
@@ -575,7 +575,7 @@ sh_test(
     name = "rbe_autoconf_config_repos_output_base_test",
     srcs = [":rbe_autoconf_output_base_config_dir_checks.sh"],
     args = [
-        "$(location @rbe_autoconfig_root//:AUTOCONF_ROOT)",
+        "$(location @rbe_autoconf_config_repos_output_base//test:empty)",
         "rbe-test-output/config/rbe_autoconf_config_repos_output_base",
         "9.0.0",
         _ubuntu1604_bazel,
@@ -586,8 +586,8 @@ sh_test(
     ],
     data = [
         ":rbe_autoconf_checks.sh",
+        "@rbe_autoconf_config_repos_output_base//test:empty",
         "@rbe_autoconf_config_repos_output_base//test:exported_testdata",
-        "@rbe_autoconfig_root//:AUTOCONF_ROOT",
     ],
 )
 
@@ -603,7 +603,7 @@ sh_test(
     name = "rbe_autoconf_output_base_config_dir_test",
     srcs = [":rbe_autoconf_output_base_config_dir_checks.sh"],
     args = [
-        "$(location @rbe_autoconfig_root//:AUTOCONF_ROOT)",
+        "$(location @rbe_autoconf_output_base_config_dir//test:empty)",
         "rbe-test-output/config/rbe_autoconf_output_base",
         "test_config_dir",
         _ubuntu1604_bazel,
@@ -613,8 +613,8 @@ sh_test(
     ],
     data = [
         ":rbe_autoconf_checks.sh",
+        "@rbe_autoconf_output_base_config_dir//test:empty",
         "@rbe_autoconf_output_base_config_dir//test:exported_testdata",
-        "@rbe_autoconfig_root//:AUTOCONF_ROOT",
     ],
 )
 
@@ -696,7 +696,7 @@ sh_test(
     name = "rbe_autoconf_custom_toolchain_config_suite_spec_export_test",
     srcs = [":rbe_autoconf_output_base_config_dir_checks.sh"],
     args = [
-        "$(location @rbe_autoconfig_root//:AUTOCONF_ROOT)",
+        "$(location @rbe_autoconf_custom_toolchain_config_suite_spec_export//test:empty)",
         "rbe-test-output/config/rbe_autoconf_custom_toolchain_config_suite_spec_export",
         "test_config_dir",
         _ubuntu1604_bazel,
@@ -706,8 +706,8 @@ sh_test(
     ],
     data = [
         ":rbe_autoconf_checks.sh",
+        "@rbe_autoconf_custom_toolchain_config_suite_spec_export//test:empty",
         "@rbe_autoconf_custom_toolchain_config_suite_spec_export//test:exported_testdata",
-        "@rbe_autoconfig_root//:AUTOCONF_ROOT",
     ],
 )
 
@@ -735,7 +735,7 @@ sh_test(
     name = "rbe_autoconf_custom_toolchain_config_suite_spec_blank_versions_test",
     srcs = [":rbe_autoconf_output_base_config_dir_checks.sh"],
     args = [
-        "$(location @rbe_autoconfig_root//:AUTOCONF_ROOT)",
+        "$(location @rbe_autoconf_custom_toolchain_config_suite_spec_blank_versions//test:empty)",
         "rbe-test-output/config/rbe_autoconf_custom_toolchain_config_suite_spec_blank_versions",
         "default_toolchain_config_spec_name",
         _ubuntu1604_bazel,
@@ -745,8 +745,8 @@ sh_test(
     ],
     data = [
         ":rbe_autoconf_checks.sh",
+        "@rbe_autoconf_custom_toolchain_config_suite_spec_blank_versions//test:empty",
         "@rbe_autoconf_custom_toolchain_config_suite_spec_blank_versions//test:exported_testdata",
-        "@rbe_autoconfig_root//:AUTOCONF_ROOT",
     ],
 )
 

--- a/tests/rbe_repo/BUILD
+++ b/tests/rbe_repo/BUILD
@@ -703,7 +703,6 @@ sh_test(
         "assert_output_base_cc_confs",
         "assert_output_base_java_confs",
         "assert_output_base_platform_confs",
-        # "assert_java_home", TODO: is this test needed here?
     ],
     data = [
         ":rbe_autoconf_checks.sh",

--- a/tests/rbe_repo/BUILD
+++ b/tests/rbe_repo/BUILD
@@ -703,7 +703,7 @@ sh_test(
         "assert_output_base_cc_confs",
         "assert_output_base_java_confs",
         "assert_output_base_platform_confs",
-        "assert_java_home",
+        # "assert_java_home", TODO: is this test needed here?
     ],
     data = [
         ":rbe_autoconf_checks.sh",

--- a/tests/rbe_repo/rbe_autoconf_checks.sh
+++ b/tests/rbe_repo/rbe_autoconf_checks.sh
@@ -146,8 +146,8 @@ assert_output_base_no_java_confs() {
 # were generated in the output_base
 assert_output_base_platform_confs() {
   assert_file_exists ${DIR}/config/BUILD
-  assert_file_exists ${DIR}/../.latest.bazelrc
-  assert_file_exists ${DIR}/../versions.bzl
+  assert_file_exists ${DIR}/../../.latest.bazelrc
+  assert_file_exists ${DIR}/../../versions.bzl
 }
 
 # Checks that files for custom repos (bazel_skylib, local_config_sh)

--- a/tests/rbe_repo/rbe_autoconf_checks.sh
+++ b/tests/rbe_repo/rbe_autoconf_checks.sh
@@ -120,32 +120,32 @@ assert_no_java_home() {
 
 # Checks that cc config files were generated in the output_base
 assert_output_base_cc_confs() {
-  assert_file_exists ${DIR}/cc/BUILD
+  assert_file_exists ${DIR}/cc/test.BUILD
   assert_file_exists ${DIR}/cc/cc_toolchain_config.bzl
   assert_file_exists ${DIR}/cc/cc_wrapper.sh
 }
 
 # Checks that cc config files were not generated in the output_base
 assert_output_base_no_cc_confs() {
-  assert_file_not_exists ${DIR}/cc/BUILD
+  assert_file_not_exists ${DIR}/cc/test.BUILD
   assert_file_not_exists ${DIR}/cc/cc_toolchain_config.bzl
   assert_file_not_exists ${DIR}/cc/cc_wrapper.sh
 }
 
 # Checks that java config files were generated in the output_base
 assert_output_base_java_confs() {
-  assert_file_exists ${DIR}/java/BUILD
+  assert_file_exists ${DIR}/java/test.BUILD
 }
 
 # Checks that java config files were not generated in the output_base
 assert_output_base_no_java_confs() {
-  assert_file_not_exists ${DIR}/java/BUILD
+  assert_file_not_exists ${DIR}/java/test.BUILD
 }
 
 # Checks that platform config files + additional output files
 # were generated in the output_base
 assert_output_base_platform_confs() {
-  assert_file_exists ${DIR}/config/BUILD
+  assert_file_exists ${DIR}/config/test.BUILD
   assert_file_exists ${DIR}/../../.latest.bazelrc
   assert_file_exists ${DIR}/../../versions.bzl
 }
@@ -154,7 +154,7 @@ assert_output_base_platform_confs() {
 # were generated in the output_base
 assert_output_base_custom_confs() {
   assert_file_exists ${DIR}/local_config_sh/WORKSPACE
-  assert_file_exists ${DIR}/local_config_sh/BUILD
+  assert_file_exists ${DIR}/local_config_sh/test.BUILD
 }
 
 # Checks that configs.tar file to export configs was generated in the remote repo

--- a/tests/rbe_repo/rbe_autoconf_output_base_config_dir_checks.sh
+++ b/tests/rbe_repo/rbe_autoconf_output_base_config_dir_checks.sh
@@ -36,5 +36,7 @@ OUTPUT_BASE=$2
 CONFIG_DIR=$3
 BAZEL_VERSION=$4
 
-OUTPUT_BASE_EMPTY=$(cat ${AUTOCONF_ROOT})/${OUTPUT_BASE}/bazel_${BAZEL_VERSION}/CONFIG_DIR/empty
+OUTPUT_BASE_EMPTY=$(cat ${AUTOCONF_ROOT})/${OUTPUT_BASE}/${CONFIG_DIR}/bazel_${BAZEL_VERSION}/empty
 set -- ${OUTPUT_BASE_EMPTY} "${@:5}"
+
+source tests/rbe_repo/rbe_autoconf_checks.sh

--- a/tests/rbe_repo/rbe_autoconf_output_base_config_dir_checks.sh
+++ b/tests/rbe_repo/rbe_autoconf_output_base_config_dir_checks.sh
@@ -31,12 +31,12 @@
 
 set -e
 
-AUTOCONF_ROOT=$1
+AUTOCONF_ROOT=$(dirname $1)/rbe_autoconf_root
 OUTPUT_BASE=$2
 CONFIG_DIR=$3
 BAZEL_VERSION=$4
 
-OUTPUT_BASE_EMPTY=$(cat ${AUTOCONF_ROOT})/${OUTPUT_BASE}/${CONFIG_DIR}/bazel_${BAZEL_VERSION}/empty
+OUTPUT_BASE_EMPTY=${AUTOCONF_ROOT}/${OUTPUT_BASE}/${CONFIG_DIR}/bazel_${BAZEL_VERSION}/empty
 set -- ${OUTPUT_BASE_EMPTY} "${@:5}"
 
 source tests/rbe_repo/rbe_autoconf_checks.sh


### PR DESCRIPTION
Fixes: https://github.com/bazelbuild/bazel-toolchains/issues/871

Previously, tests using `rbe_autoconf_output_base_config_dir_checks.sh` were not invoking any assertions.