### PR TITLE
Quote docker cli path to support Windows paths with spaces

### DIFF
--- a/rules/rbe_repo/extract.sh.tpl
+++ b/rules/rbe_repo/extract.sh.tpl
@@ -32,19 +32,19 @@ fi
 %{copy_data_cmd}
 
 # Pass an empty entrypoint to override any set by default in the container.
-id=$(${DOCKER} run -d --entrypoint "" %{docker_run_flags} %{image_name} %{commands})
+id=$("${DOCKER}" run -d --entrypoint "" %{docker_run_flags} %{image_name} %{commands})
 
-${DOCKER} wait $id
+"${DOCKER}" wait $id
 # Check the docker logs contain the expected 'created outputs_tar' string
-if ${DOCKER} logs $id | grep -q 'created outputs_tar'; then
+if "${DOCKER}" logs $id | grep -q 'created outputs_tar'; then
    echo "Successfully created outputs_tar"
 else
    echo "Could not create outputs_tar, see docker log for details:"
-   echo $(${DOCKER} logs $id)
+   echo $("${DOCKER}" logs $id)
    exit 1
 fi
-${DOCKER} cp $id:%{extract_file} %{output}
-${DOCKER} rm $id
+"${DOCKER}" cp $id:%{extract_file} %{output}
+"${DOCKER}" rm $id
 
 # If a data volumn is created, delete it at the end.
 %{clean_data_volume_cmd}


### PR DESCRIPTION
Otherwise if Docker is in "Program Files" or another directory with spaces, bash fails to execute it with an error: `./run_and_extract.sh: line 35: C:/Program: No such file or directory`