### PR TITLE
Fix print format args in RBE repo checked in configs validation

### DIFF
--- a/rules/rbe_repo/checked_in.bzl
+++ b/rules/rbe_repo/checked_in.bzl
@@ -196,12 +196,13 @@ def validateUseOfCheckedInConfigs(
         env = env,
         name = name,
     ):
-        print(("%s not using checked in configs; '%s' was picked/selected " +
-               "as a candidate matching config but it does not match " +
-               "the 'env = %s', 'config_repos = %s', " +
+        print(("%s not using checked in configs; '%s' was picked/selected as a candidate " +
+               "matching config for Bazel %s from whose list of compatible configs are %s " +
+               "but it does not match the 'env = %s', 'config_repos = %s', " +
                "and/or 'create_cc_configs = %s' passed as attrs") %
               (
                   name,
+                  config,
                   bazel_version,
                   str(bazel_compat_configs),
                   env,


### PR DESCRIPTION
Supercedes https://github.com/bazelbuild/bazel-toolchains/pull/837 as it seems to have gone stale

Taken suggestion from: https://github.com/bazelbuild/bazel-toolchains/pull/837#discussion_r387843190

We run into this as an issue when generating toolchains in a workspace with Linux and Windows toolchains, generating the Linux toolchains while there are others with checked in configs seems to hit this code and fail with: `not all arguments converted during string formatting`.