### PR TITLE
Rename target_compatible_with to internal_target_compatible_with in _rbe_config

### DIFF
--- a/rules/rbe_repo.bzl
+++ b/rules/rbe_repo.bzl
@@ -509,7 +509,7 @@ def _rbe_autoconfig_impl(ctx):
     docker_tool_path = None
 
     # Resolve default constraints if none set
-    target_compatible_with = ctx.attr.target_compatible_with
+    target_compatible_with = ctx.attr.internal_target_compatible_with
     if not target_compatible_with:
         target_compatible_with = _TARGET_COMPAT_WITH[os_family(ctx)]
 
@@ -844,7 +844,7 @@ _rbe_autoconfig = repository_rule(
         "tag": attr.string(
             doc = ("Optional. The tag of the image to pull, e.g. latest."),
         ),
-        "target_compatible_with": attr.string_list(
+        "internal_target_compatible_with": attr.string_list(
             doc = ("The list of constraints that will be added to the " +
                    "toolchain in its target_compatible_with attribute. For " +
                    "example, [\"@bazel_tools//platforms:linux\"]."),
@@ -1199,7 +1199,7 @@ def rbe_autoconfig(
         registry = registry,
         repository = repository,
         tag = tag,
-        target_compatible_with = target_compatible_with,
+        internal_target_compatible_with = target_compatible_with,
         use_checked_in_confs = use_checked_in_confs,
         use_legacy_platform_definition = use_legacy_platform_definition,
     )


### PR DESCRIPTION
This essentially the same patch as
9a2fbe254946db1323f8267e46ff1f887ed356a8 except that it deals with
`target_compatible_with` instead of `exec_properties`.

The PR bazelbuild/bazel#10945 adds a new `target_compatible_with`
attribute to all rules. That includes repository rules. Currently the
patch fails in `//src/test/shell/bazel:bazel_bootstrap_distfile_test`.
The error complains about:

>  Error in repository_rule: There is already a built-in attribute 'target_compatible_with' which cannot be overridden

Since the repository rule is abstracted by a macro, it should be
fairly safe to rename the attribute to
`internal_target_compatible_with`.