### PR TITLE
Run latest Buildifier during presubmit

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,6 +1,6 @@
 ---
 buildifier:
-  version: 0.22.0
+  version: latest
   # Check for issues with the format of our bazel config files.
   # All warnings from https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md
   # are enabled except:


### PR DESCRIPTION
Buildifier 0.22.0 is no longer supported (the current version is 4.0.1), thus leading to errors on CI: https://buildkite.com/bazel/bazel-toolchains/builds/24660