### PR TITLE
Upgrade buildifier version to one that understands --format

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,6 +1,6 @@
 ---
 buildifier:
-  version: 0.22.0
+  version: 4.0.1
   # Check for issues with the format of our bazel config files.
   # All warnings from https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md
   # are enabled except:


### PR DESCRIPTION
The `buildifier` step has been broken for many months. The assumption in the `bazelbuild/continuous-integration` repo is that `buildifier` understands a `--format` flag, but the fixed version `0.22` in this repo does not.