### PR TITLE
Allow setting the path to Bazel manually, rather than always use Bazelisk.

### DIFF
--- a/cmd/rbe_configs_gen/rbe_configs_gen.go
+++ b/cmd/rbe_configs_gen/rbe_configs_gen.go
@@ -35,6 +35,7 @@ var (
 
 	// Optional input arguments.
 	bazelVersion = flag.String("bazel_version", "", "(Optional) Bazel release version to generate configs for. E.g., 4.0.0. If unspecified, the latest available Bazel release is picked.")
+	bazelPath = flag.String("bazel_path", "", "(Optional) Path to preinstalled Bazel within the container. If unspecified, Bazelisk will be downloaded and installed.")
 
 	// Arguments affecting output generation not specific to either C++ or Java Configs.
 	outputTarball    = flag.String("output_tarball", "", "(Optional) Path where a tarball with the generated configs will be created.")
@@ -66,6 +67,9 @@ func printFlags() {
 	log.Printf("--exec_os=%q \\", *execOS)
 	log.Printf("--target_os=%q \\", *targetOS)
 	log.Printf("--bazel_version=%q \\", *bazelVersion)
+	if len(*bazelPath) != 0 {
+		log.Printf("--bazel_path=%q \\", *bazelPath)
+	}
 	if len(*outputTarball) != 0 {
 		log.Printf("--output_tarball=%q \\", *outputTarball)
 	}
@@ -148,6 +152,7 @@ func main() {
 
 	o := rbeconfigsgen.Options{
 		BazelVersion:           *bazelVersion,
+		BazelPath:              *bazelPath,
 		ToolchainContainer:     *toolchainContainer,
 		ExecOS:                 *execOS,
 		TargetOS:               *targetOS,

--- a/pkg/rbeconfigsgen/options.go
+++ b/pkg/rbeconfigsgen/options.go
@@ -31,6 +31,9 @@ type Options struct {
 	// BazelVersion is the version of Bazel to generate configs for. If unset, the latest Bazel
 	// version is automatically populated into this field when Validate() is called.
 	BazelVersion string
+	// BazelPath is the path within the container where Bazel is preinstalled. If unspecified,
+	// Bazelisk will be downloaded and installed.
+	BazelPath string
 	// ToolchainContainer is the docker image of the toolchain container to generate configs for.
 	ToolchainContainer string
 	// ExecOS is the OS of the toolchain container image or the OS in which the build actions will

--- a/pkg/rbeconfigsgen/rbeconfigsgen.go
+++ b/pkg/rbeconfigsgen/rbeconfigsgen.go
@@ -429,10 +429,10 @@ func appendCppEnv(env []string, o *Options) ([]string, error) {
 }
 
 // genCppConfigs generates C++ configs inside the running toolchain container represented by the
-// given docker runner according to the given options. bazeliskPath is the path to the bazelisk
+// given docker runner according to the given options. bazelPath is the path to the Bazel
 // binary inside the running toolchain container.
 // The return value is the path to the C++ configs tarball copied out of the toolchain container.
-func genCppConfigs(d *dockerRunner, o *Options, bazeliskPath string) (string, error) {
+func genCppConfigs(d *dockerRunner, o *Options, bazelPath string) (string, error) {
 	if !o.GenCPPConfigs {
 		return "", nil
 	}
@@ -472,7 +472,7 @@ func genCppConfigs(d *dockerRunner, o *Options, bazeliskPath string) (string, er
 	d.env = generationEnv
 
 	cmd := []string{
-		bazeliskPath,
+		bazelPath,
 		o.CppBazelCmd,
 	}
 	cmd = append(cmd, o.CPPConfigTargets...)
@@ -482,7 +482,7 @@ func genCppConfigs(d *dockerRunner, o *Options, bazeliskPath string) (string, er
 
 	// Restore the env needed for Bazelisk.
 	d.env = bazeliskEnv
-	bazelOutputRoot, err := d.execCmd(bazeliskPath, "info", "output_base")
+	bazelOutputRoot, err := d.execCmd(bazelPath, "info", "output_base")
 	if err != nil {
 		return "", fmt.Errorf("unable to determine the build output directory where Bazel produced C++ configs in the toolchain container: %w", err)
 	}
@@ -992,12 +992,15 @@ func Run(o Options) error {
 	}
 	d.workdir = workdir(o.ExecOS)
 
-	bazeliskPath, err := installBazelisk(d, o.TempWorkDir, o.ExecOS)
-	if err != nil {
-		return fmt.Errorf("failed to install Bazelisk into the toolchain container: %w", err)
+	bazelPath := o.BazelPath
+	if bazelPath == "" {
+		bazelPath, err = installBazelisk(d, o.TempWorkDir, o.ExecOS)
+		if err != nil {
+			return fmt.Errorf("failed to install Bazelisk into the toolchain container: %w", err)
+		}
 	}
 
-	cppConfigsTarball, err := genCppConfigs(d, &o, bazeliskPath)
+	cppConfigsTarball, err := genCppConfigs(d, &o, bazelPath)
 	if err != nil {
 		return fmt.Errorf("failed to generate C++ configs: %w", err)
 	}


### PR DESCRIPTION
This is sometimes desirable, e.g. when running in an airgapped environment.