### PR TITLE
Add flag to force java rule bypassing the bazel version check

### DIFF
--- a/cmd/rbe_configs_gen/rbe_configs_gen.go
+++ b/cmd/rbe_configs_gen/rbe_configs_gen.go
@@ -35,7 +35,7 @@ var (
 
 	// Optional input arguments.
 	bazelVersion = flag.String("bazel_version", "", "(Optional) Bazel release version to generate configs for. E.g., 4.0.0. If unspecified, the latest available Bazel release is picked.")
-	bazelPath = flag.String("bazel_path", "", "(Optional) Path to preinstalled Bazel within the container. If unspecified, Bazelisk will be downloaded and installed.")
+	bazelPath    = flag.String("bazel_path", "", "(Optional) Path to preinstalled Bazel within the container. If unspecified, Bazelisk will be downloaded and installed.")
 
 	// Arguments affecting output generation not specific to either C++ or Java Configs.
 	outputTarball    = flag.String("output_tarball", "", "(Optional) Path where a tarball with the generated configs will be created.")
@@ -44,10 +44,11 @@ var (
 	outputManifest   = flag.String("output_manifest", "", "(Optional) Generate a JSON file with details about the generated configs.")
 
 	// Optional input arguments that affect config generation for either C++ or Java configs.
-	genCppConfigs      = flag.Bool("generate_cpp_configs", true, "(Optional) Generate C++ configs. Defaults to true.")
-	cppEnvJSON         = flag.String("cpp_env_json", "", "(Optional) JSON file containing a str -> str dict of environment variables to be set when generating C++ configs inside the toolchain container. This replaces any exec OS specific defaults that would usually be applied.")
-	cppToolchainTarget = flag.String("cpp_toolchain_target", "", "(Optional) Set the CPP toolchain target. When exec_os is linux, the default is cc-compiler-k8. When exec_os is windows, the default is cc-compiler-x64_windows.")
-	genJavaConfigs     = flag.Bool("generate_java_configs", true, "(Optional) Generate Java configs. Defaults to true.")
+	genCppConfigs       = flag.Bool("generate_cpp_configs", true, "(Optional) Generate C++ configs. Defaults to true.")
+	cppEnvJSON          = flag.String("cpp_env_json", "", "(Optional) JSON file containing a str -> str dict of environment variables to be set when generating C++ configs inside the toolchain container. This replaces any exec OS specific defaults that would usually be applied.")
+	cppToolchainTarget  = flag.String("cpp_toolchain_target", "", "(Optional) Set the CPP toolchain target. When exec_os is linux, the default is cc-compiler-k8. When exec_os is windows, the default is cc-compiler-x64_windows.")
+	genJavaConfigs      = flag.Bool("generate_java_configs", true, "(Optional) Generate Java configs. Defaults to true.")
+	javaUseLocalRuntime = flag.Bool("java_use_local_runtime", false, "(Optional) Make the generated java toolchain use the new local_java_runtime rule instead of java_runtime. Otherwise, the Bazel version will be used to infer which rule to use.")
 
 	// Other misc arguments.
 	tempWorkDir = flag.String("temp_work_dir", "", "(Optional) Temporary directory to use to store intermediate files. Defaults to a temporary directory automatically allocated by the OS. The temporary working directory is deleted at the end unless --cleanup=false is specified.")
@@ -90,6 +91,9 @@ func printFlags() {
 	}
 	if !(*genJavaConfigs) {
 		log.Printf("--generate_java_configs=%v \\", *genJavaConfigs)
+	}
+	if *javaUseLocalRuntime {
+		log.Printf("--java_use_local_runtime=%v \\", *javaUseLocalRuntime)
 	}
 	if len(*tempWorkDir) != 0 {
 		log.Printf("--temp_work_dir=%q \\", *tempWorkDir)
@@ -164,6 +168,7 @@ func main() {
 		CppGenEnvJSON:          *cppEnvJSON,
 		CPPToolchainTargetName: *cppToolchainTarget,
 		GenJavaConfigs:         *genJavaConfigs,
+		JavaUseLocalRuntime:    *javaUseLocalRuntime,
 		TempWorkDir:            *tempWorkDir,
 		Cleanup:                *cleanup,
 	}

--- a/pkg/rbeconfigsgen/options.go
+++ b/pkg/rbeconfigsgen/options.go
@@ -89,6 +89,10 @@ type Options struct {
 	// Java config generation options.
 	// GenJavaConfigs determines whether Java configs are generated.
 	GenJavaConfigs bool
+	// JavaUseLocalRuntime forces the generated java toolchain to use the local_java_runtime
+	// rule instead of java_runtime. Otherwise, the Bazel version will be used to infer which rule
+	// to use. Older Bazel versions use java_runtime.
+	JavaUseLocalRuntime bool
 	// TempWorkDir is a temporary directory that will be used by this tool to store intermediate
 	// files. If unspecified, a temporary directory will be requested from the OS.
 	TempWorkDir string
@@ -281,6 +285,7 @@ func (o *Options) Validate() error {
 	log.Printf("CppGenEnv=%v", o.CppGenEnv)
 	log.Printf("CppGenEnvJSON=%q", o.CppGenEnvJSON)
 	log.Printf("GenJavaConfigs=%v", o.GenJavaConfigs)
+	log.Printf("JavaUseLocalRuntime=%v", o.JavaUseLocalRuntime)
 	log.Printf("TempWorkDir=%q", o.TempWorkDir)
 	log.Printf("Cleanup=%v", o.Cleanup)
 	return nil

--- a/pkg/rbeconfigsgen/rbeconfigsgen.go
+++ b/pkg/rbeconfigsgen/rbeconfigsgen.go
@@ -607,9 +607,12 @@ func genJavaConfigs(d *dockerRunner, o *Options) (generatedFile, error) {
 	}
 	log.Printf("Java version: '%s'.", javaVersion)
 
-	usesNewJavaRule, err := UsesLocalJavaRuntime(o.BazelVersion)
-	if err != nil {
-		return generatedFile{}, fmt.Errorf("unable to determine what Java toolchain rule to use for Bazel %q: %w", o.BazelVersion, err)
+	usesNewJavaRule := o.JavaUseLocalRuntime
+	if !usesNewJavaRule {
+		usesNewJavaRule, err = UsesLocalJavaRuntime(o.BazelVersion)
+		if err != nil {
+			return generatedFile{}, fmt.Errorf("unable to determine what Java toolchain rule to use for Bazel %q: %w", o.BazelVersion, err)
+		}
 	}
 	t := legacyJavaBuildTemplate
 	if usesNewJavaRule {


### PR DESCRIPTION
Forces the generated java toolchain rule to use the `local_java_runtime` rule instead of the older `java_runtime` rule. Currently, the tool infers this automatically from the given Bazel version but in some cases (e.g., Bazel nightly builds), the version string is blank and the new flags gives us the ability to force the new rule.