### PR TITLE
Pointing latest.bazelrc to the latest

### DIFF
--- a/bazelrc/latest.bazelrc
+++ b/bazelrc/latest.bazelrc
@@ -1,1 +1,1 @@
-bazel-1.0.0.bazelrc
+bazel-4.1.0.bazelrc


### PR DESCRIPTION
latest.bazelrc is a symlink meant to point to the latest bazelrc in the folder