### PR TITLE
Add support for --docker_platform flag

### DIFF
--- a/cmd/rbe_configs_gen/rbe_configs_gen.go
+++ b/cmd/rbe_configs_gen/rbe_configs_gen.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//    http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/rbe_configs_gen/rbe_configs_gen.go
+++ b/cmd/rbe_configs_gen/rbe_configs_gen.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -32,6 +32,7 @@ var (
 	toolchainContainer = flag.String("toolchain_container", "", "Repository path to toolchain image to generate configs for. E.g., l.gcr.io/google/rbe-ubuntu16-04:latest")
 	execOS             = flag.String("exec_os", "", "The OS (linux|windows) of the toolchain container image a.k.a, the execution platform in Bazel.")
 	targetOS           = flag.String("target_os", "", "The OS (linux|windows) artifacts built will target a.k.a, the target platform in Bazel.")
+	dockerPlatform     = flag.String("docker_platform", "", "(Optional) Set platform when creating container, if given the Docker server is multi-platform capable.")
 
 	// Optional input arguments.
 	bazelVersion = flag.String("bazel_version", "", "(Optional) Bazel release version to generate configs for. E.g., 4.0.0. If unspecified, the latest available Bazel release is picked.")
@@ -158,6 +159,7 @@ func main() {
 		BazelVersion:           *bazelVersion,
 		BazelPath:              *bazelPath,
 		ToolchainContainer:     *toolchainContainer,
+		DockerPlatform:         *dockerPlatform,
 		ExecOS:                 *execOS,
 		TargetOS:               *targetOS,
 		OutputTarball:          *outputTarball,

--- a/pkg/rbeconfigsgen/options.go
+++ b/pkg/rbeconfigsgen/options.go
@@ -36,6 +36,8 @@ type Options struct {
 	BazelPath string
 	// ToolchainContainer is the docker image of the toolchain container to generate configs for.
 	ToolchainContainer string
+	// Specify --platform when executing docker create.
+	DockerPlatform string
 	// ExecOS is the OS of the toolchain container image or the OS in which the build actions will
 	// execute.
 	ExecOS string
@@ -273,6 +275,7 @@ func (o *Options) Validate() error {
 	log.Printf("ToolchainContainer=%q", o.ToolchainContainer)
 	log.Printf("ExecOS=%q", o.ExecOS)
 	log.Printf("TargetOS=%q", o.TargetOS)
+	log.Printf("DockerPlatform=%q", o.DockerPlatform)
 	log.Printf("OutputTarball=%q", o.OutputTarball)
 	log.Printf("OutputSourceRoot=%q", o.OutputSourceRoot)
 	log.Printf("OutputConfigPath=%q", o.OutputConfigPath)

--- a/pkg/rbeconfigsgen/rbeconfigsgen.go
+++ b/pkg/rbeconfigsgen/rbeconfigsgen.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//    http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 package rbeconfigsgen
 
 import (


### PR DESCRIPTION
When generating configs on a Mac (esp. ones with Apple silicon) using a Linux image, the docker daemon raises a warning
```console
$ docker create --rm [a_linux_amd64_image] sleep infinity
The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
ff56913949408cfbad8d5b6d29888a741c2e1f2f3767695c78e75886619725ca
```

The `rbe_config_gen` expects the `docker create` command to return the container ID (which is 64 characters in length). The above warning breaks the contract and therefore will fail the config generation.

A possible solution is to add a `--docker_platform` flag to `rbe_config_gen` so that when it invokes `docker create`, a matching platform can be used to create the container (e.g. `rbe_config_gen --docker_platform=linux/amd64` runs `docker create --rm --platform linux/amd64 ...`).

Closes #993