### PR TITLE
Remove --host_force_python=PY2 from bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,7 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-
 # Defaults to auto which means off for Windows, explicitly enable for sh tests
 build --enable_runfiles=yes

--- a/.bazelrc
+++ b/.bazelrc
@@ -12,12 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# The following flags are set to test use of new features for python toolchains
-# These flags will only work with Bazel 0.25.0 or above.
 
-build --host_force_python=PY2
-test --host_force_python=PY2
-run --host_force_python=PY2
 
 # Defaults to auto which means off for Windows, explicitly enable for sh tests
 build --enable_runfiles=yes


### PR DESCRIPTION
Bazel is dropping support for Python 2

Setting this flag ends up forcing transitive tools to use Python 2 when they don't need to.

Fixes #995