### PR TITLE
Update java templates in rbeconfigsgen.go

### DIFF
--- a/pkg/rbeconfigsgen/rbeconfigsgen_test.go
+++ b/pkg/rbeconfigsgen/rbeconfigsgen_test.go
@@ -16,6 +16,7 @@ package rbeconfigsgen
 
 import (
 	"testing"
+  "text/template"
 )
 
 func TestGenCppToolchainTarget(t *testing.T) {
@@ -80,6 +81,105 @@ func TestGenCppToolchainTarget(t *testing.T) {
 			// regular execution.
 			if got := genCppToolchainTarget(tc.opt); got != tc.want {
 				t.Fatalf("GenCppToolchainTarget: %v, wanted %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetJavaTemplate(t *testing.T) {
+	tests := []struct {
+		name string
+		want *template.Template
+		opt  *Options
+	}{
+		{
+			name: "bazel 4, choose legacy",
+			want: legacyJavaBuildTemplate,
+			opt: &Options{
+        BazelVersion: "4.0.0",
+      },
+		},
+		{
+			name: "bazel 5, choose BazelLt7",
+			want: javaBuildTemplateLt7,
+			opt: &Options{
+        BazelVersion: "5.0.0",
+			},
+		},
+		{
+			name: "bazel 7, choose latest",
+			want: javaBuildTemplate,
+			opt: &Options{
+        BazelVersion: "7.0.0",
+			},
+		},
+		{
+			name: "bazel 7-pre, choose latest",
+			want: javaBuildTemplate,
+			opt: &Options{
+        BazelVersion: "7.0.0-pre.20230724.1",
+			},
+		},
+		{
+			name: "useLocalRuntime forced, choose latest",
+			want: javaBuildTemplate,
+			opt: &Options{
+			  JavaUseLocalRuntime: true,
+			},
+		},
+		{
+			name: "useLocalRuntime forced, bazel 4, choose BazelLt7",
+			want: javaBuildTemplateLt7,
+			opt: &Options{
+			  BazelVersion: "4.0.0",
+			  JavaUseLocalRuntime: true,
+			},
+		},
+		{
+			name: "useLocalRuntime forced, bazel 5, choose BazelLt7",
+			want: javaBuildTemplateLt7,
+			opt: &Options{
+			  BazelVersion: "5.0.0",
+			  JavaUseLocalRuntime: true,
+			},
+		},
+		{
+			name: "useLocalRuntime forced, bazel 6, choose BazelLt7",
+			want: javaBuildTemplateLt7,
+			opt: &Options{
+			  BazelVersion: "6.0.0",
+			  JavaUseLocalRuntime: true,
+			},
+		},
+		{
+			name: "useLocalRuntime forced, bazel 7, choose latest",
+			want: javaBuildTemplate,
+			opt: &Options{
+			  BazelVersion: "7.0.0",
+			  JavaUseLocalRuntime: true,
+			},
+		},
+		{
+			name: "useLocalRuntime forced, bazel 7-pre, choose latest",
+			want: javaBuildTemplate,
+			opt: &Options{
+			  BazelVersion: "7.0.0-pre.20200202",
+			  JavaUseLocalRuntime: true,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// We skip validation since we don't set all options required for
+			// regular execution.
+			got, err := getJavaTemplate(tc.opt);
+			if err != nil {
+			  t.Fatalf("getJavaTemplate failed: %v, wanted: %v", err, tc.want)
+			} else if got != tc.want {
+				t.Fatalf("getJavaTemplate: %v, wanted %v", got, tc.want)
 			}
 		})
 	}

--- a/rules/exec_properties/exec_properties.bzl
+++ b/rules/exec_properties/exec_properties.bzl
@@ -203,7 +203,7 @@ PARAMS = {
     ),
 }
 
-def create_exec_properties_dict(**kwargs):
+def create_exec_properties_dict(**_kwargs):
     fail("create_exec_properties_dict is deprecated. Please use create_rbe_exec_properties_dict instead.")
 
 def create_rbe_exec_properties_dict(**kwargs):
@@ -242,7 +242,7 @@ def create_rbe_exec_properties_dict(**kwargs):
 
     return dict
 
-def merge_dicts(*dict_args):
+def merge_dicts(*_dict_args):
     fail("merge_dicts is deprecated. Please use dicts.add() instead. See https://github.com/bazelbuild/bazel-skylib/blob/master/docs/dicts_doc.md")
 
 def _exec_property_sets_repository_impl(repository_ctx):


### PR DESCRIPTION
Uses @rules_java for bazel > 7.0.0 (including pre-releases)

 - Added tests for java template resolution, but I can't seem to find any reference to that file. Is that configured somewhere in CI or only meant for manual runs?
 - I've made sure to preserve existing behavior as much as possible. The only difference is if `--bazel_version` is not passed, we use the latest template. 
 - I'm not happy about the naming of the templates, but I plan to clean this once support for 4.0.0 is dropped in Jan 2024, and we can bring down the number of java templates to 2.