### PR TITLE
rbeconfigsgen: Migrate off `local_config_platform`

### DIFF
--- a/pkg/rbeconfigsgen/rbeconfigsgen.go
+++ b/pkg/rbeconfigsgen/rbeconfigsgen.go
@@ -79,7 +79,7 @@ toolchain(
 
 platform(
     name = "platform",
-    parents = ["@local_config_platform//:host"],
+    parents = ["@platforms//host"],
     constraint_values = [
 {{ range .ExecConstraints }}        "{{ . }}",
 {{ end }}    ],


### PR DESCRIPTION
`local_config_platform` is going to be removed in Bazel 9 (see https://github.com/bazelbuild/bazel/issues/22080). This switches it to the replacement, `@platforms//host`.

Work towards https://github.com/bazelbuild/bazel/issues/26213