### PR TITLE
Add --host_bazel_path option to rbe_configs_gen

### DIFF
--- a/cmd/rbe_configs_gen/rbe_configs_gen.go
+++ b/cmd/rbe_configs_gen/rbe_configs_gen.go
@@ -36,8 +36,9 @@ var (
 	dockerPlatform     = flag.String("docker_platform", "", "(Optional) Set platform when creating container, if given the Docker server is multi-platform capable.")
 
 	// Optional input arguments.
-	bazelVersion = flag.String("bazel_version", "", "(Optional) Bazel release version to generate configs for. E.g., 4.0.0. If unspecified, the latest available Bazel release is picked.")
+	bazelVersion = flag.String("bazel_version", "", "(Optional) Bazel release version to generate configs for. E.g., 4.0.0. If unspecified, the latest available Bazel release is picked. Cannot be specified if --host_bazel_path is used.")
 	bazelPath    = flag.String("bazel_path", "", "(Optional) Path to preinstalled Bazel within the container. If unspecified, Bazelisk will be downloaded and installed.")
+	hostBazelPath = flag.String("host_bazel_path", "", "(Optional) Path on the host machine to a Bazel binary. If specified, this binary will be copied into the container and used for config generation. The Bazel version will be automatically detected from this binary, so --bazel_version cannot be specified alongside this flag.")
 
 	// Arguments affecting output generation not specific to either C++ or Java Configs.
 	outputTarball    = flag.String("output_tarball", "", "(Optional) Path where a tarball with the generated configs will be created.")
@@ -75,6 +76,9 @@ func printFlags() {
 	log.Printf("--bazel_version=%q \\", *bazelVersion)
 	if len(*bazelPath) != 0 {
 		log.Printf("--bazel_path=%q \\", *bazelPath)
+	}
+	if len(*hostBazelPath) != 0 {
+		log.Printf("--host_bazel_path=%q \\", *hostBazelPath)
 	}
 	if len(*outputTarball) != 0 {
 		log.Printf("--output_tarball=%q \\", *outputTarball)
@@ -173,6 +177,7 @@ func main() {
 	o := rbeconfigsgen.Options{
 		BazelVersion:           *bazelVersion,
 		BazelPath:              *bazelPath,
+		HostBazelPath:          *hostBazelPath,
 		ToolchainContainer:     *toolchainContainer,
 		DockerPlatform:         *dockerPlatform,
 		ExecOS:                 *execOS,

--- a/pkg/rbeconfigsgen/options.go
+++ b/pkg/rbeconfigsgen/options.go
@@ -19,6 +19,7 @@ package rbeconfigsgen
 import (
 	"fmt"
 	"log"
+	"os/exec"
 	"path"
 	"strings"
 
@@ -30,10 +31,16 @@ import (
 type Options struct {
 	// BazelVersion is the version of Bazel to generate configs for. If unset, the latest Bazel
 	// version is automatically populated into this field when Validate() is called.
+	// Cannot be specified if HostBazelPath is used.
 	BazelVersion string
 	// BazelPath is the path within the container where Bazel is preinstalled. If unspecified,
 	// Bazelisk will be downloaded and installed.
 	BazelPath string
+	// HostBazelPath is the path on the host machine to a Bazel binary. If specified, this
+	// binary will be copied into the container and used for config generation.
+	// The Bazel version will be automatically detected from this binary, so BazelVersion
+	// cannot be specified alongside this option.
+	HostBazelPath string
 	// ToolchainContainer is the docker image of the toolchain container to generate configs for.
 	ToolchainContainer string
 	// Specify --platform when executing docker create.
@@ -237,12 +244,33 @@ func latestBazelVersion() (string, error) {
 // Validate verifies that mandatory arguments were provided and argument values don't conflict in
 // certain cases.
 func (o *Options) Validate() error {
+	if o.BazelPath != "" && o.HostBazelPath != "" {
+		return fmt.Errorf("only one of BazelPath or HostBazelPath must be specified")
+	}
+	if o.HostBazelPath != "" && o.BazelVersion != "" {
+		return fmt.Errorf("BazelVersion cannot be specified when HostBazelPath is used (the version will be automatically detected)")
+	}
 	if o.BazelVersion == "" {
-		v, err := latestBazelVersion()
-		if err != nil {
-			return fmt.Errorf("BazelVersion wasn't specified and was unable to determine the latest available Bazel version: %w", err)
+		if o.HostBazelPath != "" {
+			v, err := detectBazelVersion(o.HostBazelPath)
+			if err == nil {
+				o.BazelVersion = v
+				log.Printf("Automatically detected Bazel version from host_bazel_path: %s", o.BazelVersion)
+			} else {
+				log.Printf("Warning: failed to detect Bazel version from host_bazel_path %q: %v. Falling back to latest Bazel version.", o.HostBazelPath, err)
+				v, err := latestBazelVersion()
+				if err != nil {
+					return fmt.Errorf("BazelVersion wasn't specified and was unable to determine the latest available Bazel version: %w", err)
+				}
+				o.BazelVersion = v
+			}
+		} else {
+			v, err := latestBazelVersion()
+			if err != nil {
+				return fmt.Errorf("BazelVersion wasn't specified and was unable to determine the latest available Bazel version: %w", err)
+			}
+			o.BazelVersion = v
 		}
-		o.BazelVersion = v
 	}
 	if o.ToolchainContainer == "" {
 		return fmt.Errorf("ToolchainContainer was not specified")
@@ -285,6 +313,8 @@ func (o *Options) Validate() error {
 	}
 	log.Printf("rbeconfigsgen.Options:")
 	log.Printf("BazelVersion=%q", o.BazelVersion)
+	log.Printf("BazelPath=%q", o.BazelPath)
+	log.Printf("HostBazelPath=%q", o.HostBazelPath)
 	log.Printf("ToolchainContainer=%q", o.ToolchainContainer)
 	log.Printf("ExecOS=%q", o.ExecOS)
 	log.Printf("TargetOS=%q", o.TargetOS)
@@ -305,4 +335,16 @@ func (o *Options) Validate() error {
 	log.Printf("TempWorkDir=%q", o.TempWorkDir)
 	log.Printf("Cleanup=%v", o.Cleanup)
 	return nil
+}
+
+func detectBazelVersion(bazelPath string) (string, error) {
+	out, err := exec.Command(bazelPath, "--version").Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to run %q: %w", bazelPath, err)
+	}
+	output := strings.TrimSpace(string(out))
+	if !strings.HasPrefix(output, "bazel ") {
+		return "", fmt.Errorf("unexpected version output: %q", output)
+	}
+	return strings.TrimPrefix(output, "bazel "), nil
 }

--- a/pkg/rbeconfigsgen/rbeconfigsgen.go
+++ b/pkg/rbeconfigsgen/rbeconfigsgen.go
@@ -570,8 +570,14 @@ func genCppConfigs(d *dockerRunner, o *Options, bazelPath string) (string, error
 	return outputTarballPath, nil
 }
 
-// Returns if bazelVersion >= targetBazelVersion.
-func isBazelVersionLessThan(bazelVersion, targetBazelVersion string) bool {
+// Returns if bazelVersion < targetBazelVersion.
+func isBazelVersionLessThan(bazelVersion, targetBazelVersion string) (res bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("Warning: panic during version comparison for %q: %v. Assuming it is a development version (newer).", bazelVersion, r)
+			res = false // Assume it is NOT less than target (i.e., it is newer)
+		}
+	}()
 	sorted := versions.GetInAscendingOrder([]string{targetBazelVersion, bazelVersion})
 	return sorted[0] != targetBazelVersion
 }
@@ -1061,8 +1067,24 @@ func Run(o Options) error {
 	}
 	d.workdir = workdir(o.ExecOS)
 
-	bazelPath := o.BazelPath
-	if bazelPath == "" {
+	var bazelPath string
+	if o.HostBazelPath != "" {
+		if _, err := os.Stat(o.HostBazelPath); err != nil {
+			return fmt.Errorf("failed to stat host_bazel_path %q: %w", o.HostBazelPath, err)
+		}
+		log.Printf("Host bazel_path detected: %s. Copying to container...", o.HostBazelPath)
+		filename := filepath.Base(o.HostBazelPath)
+		bazelContainerPath := path.Join(d.workdir, filename)
+		if err := d.copyToContainer(o.HostBazelPath, bazelContainerPath); err != nil {
+			return fmt.Errorf("failed to copy host Bazel binary %q into the container: %w", o.HostBazelPath, err)
+		}
+		if _, err := d.execCmd("chmod", "+x", bazelContainerPath); err != nil {
+			return fmt.Errorf("failed to mark the Bazel binary as executable inside the container: %w", err)
+		}
+		bazelPath = bazelContainerPath
+	} else if o.BazelPath != "" {
+		bazelPath = o.BazelPath
+	} else {
 		bazelPath, err = installBazelisk(d, o.TempWorkDir, o.ExecOS)
 		if err != nil {
 			return fmt.Errorf("failed to install Bazelisk into the toolchain container: %w", err)

--- a/pkg/rbeconfigsgen/rbeconfigsgen_test.go
+++ b/pkg/rbeconfigsgen/rbeconfigsgen_test.go
@@ -15,8 +15,10 @@
 package rbeconfigsgen
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
-  "text/template"
+	"text/template"
 )
 
 func TestGenCppToolchainTarget(t *testing.T) {
@@ -167,6 +169,13 @@ func TestGetJavaTemplate(t *testing.T) {
 			  JavaUseLocalRuntime: true,
 			},
 		},
+		{
+			name: "development version, choose latest",
+			want: javaBuildTemplate,
+			opt: &Options{
+			  BazelVersion: "development version",
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -180,6 +189,183 @@ func TestGetJavaTemplate(t *testing.T) {
 			  t.Fatalf("getJavaTemplate failed: %v, wanted: %v", err, tc.want)
 			} else if got != tc.want {
 				t.Fatalf("getJavaTemplate: %v, wanted %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDetectBazelVersion(t *testing.T) {
+	tmpDir := t.TempDir()
+	
+	// Test case 1: Valid version output
+	bazelScript := filepath.Join(tmpDir, "bazel_valid")
+	err := os.WriteFile(bazelScript, []byte("#!/bin/sh\necho 'bazel 5.4.0'\n"), 0755)
+	if err != nil {
+		t.Fatalf("Failed to write test script: %v", err)
+	}
+	
+	got, err := detectBazelVersion(bazelScript)
+	if err != nil {
+		t.Errorf("detectBazelVersion failed: %v", err)
+	}
+	if got != "5.4.0" {
+		t.Errorf("detectBazelVersion = %q, want 5.4.0", got)
+	}
+	
+	// Test case 2: Custom/development version output
+	bazelScriptDev := filepath.Join(tmpDir, "bazel_dev")
+	err = os.WriteFile(bazelScriptDev, []byte("#!/bin/sh\necho 'bazel development version'\n"), 0755)
+	if err != nil {
+		t.Fatalf("Failed to write test script: %v", err)
+	}
+	
+	got, err = detectBazelVersion(bazelScriptDev)
+	if err != nil {
+		t.Errorf("detectBazelVersion failed: %v", err)
+	}
+	if got != "development version" {
+		t.Errorf("detectBazelVersion = %q, want development version", got)
+	}
+
+	// Test case 3: Invalid output format
+	bazelScriptInvalid := filepath.Join(tmpDir, "bazel_invalid")
+	err = os.WriteFile(bazelScriptInvalid, []byte("#!/bin/sh\necho 'some random output'\n"), 0755)
+	if err != nil {
+		t.Fatalf("Failed to write test script: %v", err)
+	}
+	
+	_, err = detectBazelVersion(bazelScriptInvalid)
+	if err == nil {
+		t.Errorf("detectBazelVersion expected error for invalid output, got nil")
+	}
+}
+
+func TestOptionsValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		opt     *Options
+		wantErr bool
+	}{
+		{
+			name: "Both BazelPath and HostBazelPath set",
+			opt: &Options{
+				BazelPath:     "/bin/bazel",
+				HostBazelPath: "/usr/bin/bazel",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Both HostBazelPath and BazelVersion set",
+			opt: &Options{
+				HostBazelPath: "/usr/bin/bazel",
+				BazelVersion:  "5.4.0",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Only HostBazelPath set (valid)",
+			opt: &Options{
+				HostBazelPath: "/usr/bin/bazel",
+			},
+			wantErr: false,
+		},
+	}
+	
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// Populate mandatory fields to avoid unrelated validation errors
+			if tc.opt.ToolchainContainer == "" {
+				tc.opt.ToolchainContainer = "dummy"
+			}
+			if tc.opt.ExecOS == "" {
+				tc.opt.ExecOS = "linux"
+			}
+			if tc.opt.TargetOS == "" {
+				tc.opt.TargetOS = "linux"
+			}
+			if tc.opt.OutputTarball == "" && tc.opt.OutputSourceRoot == "" {
+				tc.opt.OutputTarball = "dummy.tar"
+			}
+			if tc.opt.PlatformParams == nil {
+				tc.opt.PlatformParams = &PlatformToolchainsTemplateParams{}
+			}
+			tc.opt.GenCPPConfigs = true
+			tc.opt.CPPConfigTargets = []string{"dummy"}
+			tc.opt.CppBazelCmd = "build"
+
+			// If HostBazelPath is set and we expect no error, we must make sure it points to a valid file
+			// because Validate() will try to detect version by running it!
+			if tc.name == "Only HostBazelPath set (valid)" {
+				tmpDir := t.TempDir()
+				bazelScript := filepath.Join(tmpDir, "bazel")
+				err := os.WriteFile(bazelScript, []byte("#!/bin/sh\necho 'bazel 5.4.0'\n"), 0755)
+				if err != nil {
+					t.Fatalf("Failed to write test script: %v", err)
+				}
+				tc.opt.HostBazelPath = bazelScript
+			}
+
+			err := tc.opt.Validate()
+			if (err != nil) != tc.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestIsBazelVersionLessThan(t *testing.T) {
+	tests := []struct {
+		name          string
+		bazelVersion  string
+		targetVersion string
+		want          bool
+	}{
+		{
+			name:          "Standard comparison - less",
+			bazelVersion:  "5.0.0",
+			targetVersion: "6.0.0",
+			want:          true,
+		},
+		{
+			name:          "Standard comparison - equal",
+			bazelVersion:  "6.0.0",
+			targetVersion: "6.0.0",
+			want:          false,
+		},
+		{
+			name:          "Standard comparison - greater",
+			bazelVersion:  "7.0.0",
+			targetVersion: "6.0.0",
+			want:          false,
+		},
+		{
+			name:          "Pre-release comparison",
+			bazelVersion:  "7.0.0-pre.1",
+			targetVersion: "7.0.0",
+			want:          true,
+		},
+		{
+			name:          "Unparseable version (panic recovery) - development version",
+			bazelVersion:  "development version",
+			targetVersion: "6.0.0",
+			want:          false, // Should recover and assume newer (not less)
+		},
+		{
+			name:          "Unparseable version (panic recovery) - custom build",
+			bazelVersion:  "my-custom-build",
+			targetVersion: "6.0.0",
+			want:          false, // Should recover and assume newer (not less)
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := isBazelVersionLessThan(tc.bazelVersion, tc.targetVersion)
+			if got != tc.want {
+				t.Errorf("isBazelVersionLessThan(%q, %q) = %v, want %v", tc.bazelVersion, tc.targetVersion, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
This option allows specifying a local Bazel binary on the host machine. If specified, the binary is copied into the container and used for generating the toolchain configurations.

The Bazel version is automatically detected from the host binary by running it with `--version` locally. Consequently, `--bazel_version` cannot be specified alongside `--host_bazel_path`.

Added unit tests to verify:
- Automatic version detection and parsing.
- Validation rules (mutual exclusivity of HostBazelPath with BazelPath and BazelVersion).
- Robust version comparison with panic recovery for unparseable/custom versions (e.g., "development version").