### PR TITLE
rbeconfigsgen: Conditionally use @platforms//host based on Bazel version

### DIFF
--- a/pkg/rbeconfigsgen/rbeconfigsgen.go
+++ b/pkg/rbeconfigsgen/rbeconfigsgen.go
@@ -79,7 +79,7 @@ toolchain(
 
 platform(
     name = "platform",
-    parents = ["@platforms//host"],
+    parents = ["{{.ParentPlatform}}"],
     constraint_values = [
 {{ range .ExecConstraints }}        "{{ . }}",
 {{ end }}    ],
@@ -160,11 +160,12 @@ type PlatformToolchainsTemplateParams struct {
 	CppToolchainTarget string
 	ToolchainContainer string
 	OSFamily           string
+	ParentPlatform     string
 }
 
 func (p PlatformToolchainsTemplateParams) String() string {
-	return fmt.Sprintf("{ExecConstraints: %v, TargetConstraints: %v, CppToolchainTarget: %q, ToolchainContainer: %q, OSFamily: %q}",
-		p.ExecConstraints, p.TargetConstraints, p.CppToolchainTarget, p.ToolchainContainer, p.OSFamily)
+	return fmt.Sprintf("{ExecConstraints: %v, TargetConstraints: %v, CppToolchainTarget: %q, ToolchainContainer: %q, OSFamily: %q, ParentPlatform: %q}",
+		p.ExecConstraints, p.TargetConstraints, p.CppToolchainTarget, p.ToolchainContainer, p.OSFamily, p.ParentPlatform)
 }
 
 // javaBuildTemplateParams is used as the input to the Java toolchains BUILD file template.
@@ -745,6 +746,13 @@ func genConfigBuild(o *Options) (generatedFile, error) {
 		o.PlatformParams.CppToolchainTarget = ""
 		log.Printf("Not generating a toolchain target to be used for the C++ Crosstool top because C++ config generation is disabled.")
 	}
+
+	if isBazelVersionLessThan(o.BazelVersion, "7.0.0") {
+		o.PlatformParams.ParentPlatform = "@local_config_platform//:host"
+	} else {
+		o.PlatformParams.ParentPlatform = "@platforms//host"
+	}
+
 	buf := bytes.NewBuffer(nil)
 	log.Printf("Fully resolved platform params=%v", o.PlatformParams)
 	if err := platformsToolchainBuildTemplate.Execute(buf, o.PlatformParams); err != nil {

--- a/pkg/rbeconfigsgen/rbeconfigsgen_test.go
+++ b/pkg/rbeconfigsgen/rbeconfigsgen_test.go
@@ -17,6 +17,7 @@ package rbeconfigsgen
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"text/template"
 )
@@ -407,6 +408,58 @@ func TestCppConfigTargetAndRepo(t *testing.T) {
 			}
 			if gotRepo != tc.wantRepo {
 				t.Errorf("cppConfigTargetAndRepo(%q) gotRepo = %q, want %q", tc.bazelVersion, gotRepo, tc.wantRepo)
+			}
+		})
+	}
+}
+
+func TestGenConfigBuild(t *testing.T) {
+	tests := []struct {
+		name         string
+		bazelVersion string
+		wantParent   string
+	}{
+		{
+			name:         "Bazel 6",
+			bazelVersion: "6.4.0",
+			wantParent:   "@local_config_platform//:host",
+		},
+		{
+			name:         "Bazel 7",
+			bazelVersion: "7.0.0",
+			wantParent:   "@platforms//host",
+		},
+		{
+			name:         "Bazel 8",
+			bazelVersion: "8.0.0",
+			wantParent:   "@platforms//host",
+		},
+		{
+			name:         "Development version",
+			bazelVersion: "development version",
+			wantParent:   "@platforms//host",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			opt := &Options{
+				BazelVersion: tc.bazelVersion,
+				PlatformParams: &PlatformToolchainsTemplateParams{
+					ExecConstraints: []string{"@platforms//os:linux"},
+				},
+			}
+			gotFile, err := genConfigBuild(opt)
+			if err != nil {
+				t.Fatalf("genConfigBuild failed: %v", err)
+			}
+			
+			// Check if the generated content contains the expected parent platform
+			content := string(gotFile.contents)
+			expected := `parents = ["` + tc.wantParent + `"]`
+			if !strings.Contains(content, expected) {
+				t.Errorf("Expected content to contain %q, but got:\n%s", expected, content)
 			}
 		})
 	}


### PR DESCRIPTION
Commit cb0929a385a058d1839db410e0aca4d23e3543df changed the generated toolchain to use @platforms//host instead of @local_config_platform//:host. However, this breaks toolchain generation with Bazel 6 because @platforms//host is not supported in Bazel 6.

This change dynamically selects the parent platform:
- @local_config_platform//:host for Bazel < 7
- @platforms//host for Bazel >= 7

Added TestGenConfigBuild to verify the behavior.